### PR TITLE
Add copy of image so that the original one is not overwritten.

### DIFF
--- a/magicctapipe/image/cleaning.py
+++ b/magicctapipe/image/cleaning.py
@@ -184,6 +184,7 @@ class MAGICClean:
 
         if self.find_hotpixels:
 
+            self.event_image = copy.copy(event_image)
             self.event_image, self.event_pulse_time, self.unsuitable_mask, self.unmapped_mask = self.pixel_treatment.treat(event_image, event_pulse_time,unsuitable_mask)
             self.event_image[self.unmapped_mask] = 0.0
 


### PR DESCRIPTION
In the case that bad/hot pixels treatment is used, the original calibrated image was overwritten during the cleaning. Now the behavior is consistent if the pixel treatment is used or not.