### PR TITLE
Fix magic calibration

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -44,9 +44,13 @@ LST:
 
 MAGIC:
     image_extractor:
-        type: 'LocalPeakWindowSum'
-        window_shift: 2
+        type: 'SlidingWindowMaxSum'
         window_width: 5
+        apply_integration_correction: false
+
+    charge_correction:
+        use: true
+        correction_factor: 1.165
 
     magic_clean:
         use_time: true

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -173,6 +173,8 @@ def mc_dl0_to_dl1(input_file, output_dir, config):
         subarray=subarray,
     )
 
+    use_charge_correction = config_magic['charge_correction'].pop('use')
+
     # Prepare for saving data to an output file:
     Path(output_dir).mkdir(exist_ok=True, parents=True)
 
@@ -278,6 +280,9 @@ def mc_dl0_to_dl1(input_file, output_dir, config):
                     # Calibrate the event:
                     calibrator_magic._calibrate_dl0(event, tel_id)
                     calibrator_magic._calibrate_dl1(event, tel_id)
+
+                    if use_charge_correction:
+                        event.dl1.tel[tel_id].image *= config_magic['charge_correction']['correction_factor']
 
                     # Apply the image cleaning:
                     signal_pixels, image, peak_time = magic_clean.clean_image(


### PR DESCRIPTION
This pull request changes the extractor type from the LocalPeakWindowSum to SlidingWindowMaxSum which is used in MARS analyses, and disables the integration correction. Also, a correction factor is applied to DL1 images which is derived from the difference of the conversion factors 1.165 (= 0.0155/0.0133) between MARS and simtel.