### PR TITLE
Cast is_valid to int before writing it out.

### DIFF
--- a/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
@@ -250,7 +250,7 @@ def stereo_reconstruction(input_file, output_dir, config):
             event_data.loc[(obs_id, event_id, tel_id), 'core_x'] = stereo_params.core_x.to(u.m).value
             event_data.loc[(obs_id, event_id, tel_id), 'core_y'] = stereo_params.core_y.to(u.m).value
             event_data.loc[(obs_id, event_id, tel_id), 'impact'] = impact.to(u.m).value
-            event_data.loc[(obs_id, event_id, tel_id), 'is_valid'] = stereo_params.is_valid
+            event_data.loc[(obs_id, event_id, tel_id), 'is_valid'] = int(stereo_params.is_valid)
 
     n_events_processed = i_evt + 1
     logger.info(f'{n_events_processed} events')


### PR DESCRIPTION
is_valid is cast to int (from bool) before writing it out, otherwise pytables complains when writing the file.