### PR TITLE
modified dl0_to_dl1 script to allow processing files with file names following LSTProd2 style

### DIFF
--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -212,7 +212,7 @@ def mc_dl0_to_dl1(input_file, output_dir, config, muons_analysis):
     Path(output_dir).mkdir(exist_ok=True, parents=True)
 
     regex_off = r'(\S+)_run(\d+)_.*_off(\S+)\.simtel.gz'
-    regex = r'(\S+)_run(\d+)_.*\.simtel.gz'
+    regex = r'(\S+)_run(\d+)[_\.].*simtel.gz'
 
     file_name = Path(input_file).resolve().name
 


### PR DESCRIPTION
the regular expression expected run number then _ and arbitrary text followed with .simtel.gz
but LSTProd2 files have e.g. run999.simtel.gz.
Now the regular expression wants either . or _ after the run number, arbitrary (possibly empty) text and simtel.gz

I checked that it works on the lstprod "train" files, and on the original @YoshikiOhtani proton files (the gamma files of @YoshikiOhtani are using a separate regex) 