### PR TITLE
changed the time limits of the MAGIC cleaning to ns units

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -55,8 +55,8 @@ MAGIC:
         use_sum: true
         picture_thresh: 6
         boundary_thresh: 3.5
-        max_time_off: 7.38
-        max_time_diff: 2.46
+        max_time_off: 4.5
+        max_time_diff: 1.5
         find_hotpixels: 'auto'
         pedestal_type: 'from_extractor_rndm'   # select 'fundamental', 'from_extractor' or 'from_extractor_rndm'
 


### PR DESCRIPTION
this needs to be correlated with the update of ctapipe_io_magic:
https://github.com/cta-observatory/ctapipe_io_magic/pull/48