### PR TITLE
Add magic only option to the stereo reconstruction

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -74,7 +74,7 @@ event_coincidence:
 
 
 stereo_reco:
-    event_cuts: '(intensity > 50) & (width > 0)'
+    quality_cuts: '(intensity > 50) & (width > 0)'
     theta_uplim: 6   # unit: [arcmin]
 
 
@@ -198,18 +198,18 @@ create_irf:
         n_bins: 20   # number of bins in linear space
 
     gammaness:
-        cut_type: 'global'   # select 'global' or 'dynamic'
-        global_cut_value: 0.6   # used for the global cut
-        gamma_efficiency: null   # used for the dynamic cut
-        min_cut: 0.05 # minimum value of cut
-        max_cut: 0.85  # maximum value of cut
+        cut_type: 'dynamic'   # select 'global' or 'dynamic'
+        global_cut_value: null   # used for the global cut
+        gamma_efficiency: 0.9   # used for the dynamic cut
+        min_cut: 0.05   # minimum value of cut
+        max_cut: 0.85   # maximum value of cut
 
     theta:
         cut_type: 'global'   # select 'global' or 'dynamic'
         global_cut_value: 0.2   # used for the global cut
         gamma_efficiency: null   # used for the dynamic cut
-        min_cut: 0.1 # minimum value of cut
-        max_cut: 0.45  # maximum value of cut
+        min_cut: null   # minimum value of cut
+        max_cut: null   # maximum value of cut
 
 
 dl2_to_dl3:

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
@@ -2,15 +2,15 @@
 # coding: utf-8
 
 """
-Author: Yoshiki Ohtani (ICRR, ohtani@icrr.u-tokyo.ac.jp)
-
 This script processes DL1 events and reconstructs the stereo parameters with more than one telescope information.
-Event cuts specified in a configuration file are applied to events before the reconstruction.
+The quality cuts specified in a configuration file are applied to events before the reconstruction.
 
-When an input is real data containing LST-1 and MAGIC events, it checks the angular distance of the LST-1 and MAGIC pointing directions.
+When an input is real data containing LST-1 and MAGIC events, it checks the angular distance of their pointing directions.
 Then, it stops the process when the distance is larger than the limit specified in a configuration file.
-This is in principle to avoid the reconstruction of too mis-pointing data, for example,
-DL1 data may contain coincident events which are taken with different wobble offsets between the systems.
+This is in principle to avoid the reconstruction of the data taken in a too-mispointing condition, for example,
+DL1 data may contain the coincident events which are taken with different wobble offsets between the systems.
+
+If the "--magic-only" option is given, it reconstructs the stereo parameters using only MAGIC images.
 
 Usage:
 $ python lst1_magic_stereo_reco.py


### PR DESCRIPTION
This pull request adds the option "--magic-only" to the `lst1_magic_stereo_reco.py` to automatically perform the stereo reconstruction using only MAGIC images. By using this, one does not need to add the `tel_id > 1` condition in the config file. @aleberti and @ellijobst, please use this if it is comfortable for you.