### PR TITLE
Fixed a bug of using non-inverse error for weights

### DIFF
--- a/magicctapipe/utils/functions.py
+++ b/magicctapipe/utils/functions.py
@@ -73,7 +73,7 @@ def calculate_mean_direction(lon, lat, weights=None):
     lon: pandas.core.series.Series
         Longitude in a spherical coordinate
     lat: pandas.core.series.Series
-        Latitude in a spherical coodinate
+        Latitude in a spherical coordinate
     weights: pandas.core.series.Series
         Weights applied when calculating the mean direction
 
@@ -342,7 +342,7 @@ def get_dl2_mean(event_data):
     reco_az_mean, reco_alt_mean = calculate_mean_direction(
         lon=np.deg2rad(event_data['reco_az']),
         lat=np.deg2rad(event_data['reco_alt']),
-        weights=event_data['reco_disp_err'],
+        weights=1/event_data['reco_disp_err'],
     )
 
     # Compute the mean of the telescope pointing directions:


### PR DESCRIPTION
When I was looking into the issue #69, I found that when averaging the telescope-wise reconstructed directions the pipeline uses the errors which are not inverse. This makes the reconstruction performance worse because it weights to the reco parameter whose error is large. I checked that fixing this issue and using the inverse errors improve the angular resolutions, please see the attached two plots for the comparison of the resolutions before and after fixing the bug.

![angres_magic_bugfix](https://user-images.githubusercontent.com/39613098/170727346-54219782-c470-42dd-aa81-066f82ecc904.png)
![angres_mlst_bugfix](https://user-images.githubusercontent.com/39613098/170727351-2fbd9492-ad4c-4cd5-b62d-5bd54117b5b5.png)

@jsitarek, since it should affect your analysis, please give me an approval when you acknowledge this fix. Thanks!