### PR TITLE
Refactor MC DL0 to DL1 script

### DIFF
--- a/magicctapipe/image/muons/muon_analysis.py
+++ b/magicctapipe/image/muons/muon_analysis.py
@@ -6,7 +6,7 @@ __all__ = [
 ]
 
 
-def perform_muon_analysis(muon_parameters, event, telescope_id, telescope_name, image, subarray,
+def perform_muon_analysis(muon_parameters, event, telescope_id, image, subarray,
                           r1_dl1_calibrator_for_muon_rings, good_ring_config, event_time=np.nan,
                           min_pe_for_muon_t_calc=10., data_type='mc'):
     """
@@ -18,8 +18,6 @@ def perform_muon_analysis(muon_parameters, event, telescope_id, telescope_name, 
     event: ctapipe event container
     telescope_id: int
         Id of the telescope
-    telescope_name: string
-        Name of teh telescope
     image:  `np.ndarray`
         Number of photoelectrons in each pixel
     subarray: `ctapipe.instrument.subarray.SubarrayDescription`
@@ -111,4 +109,3 @@ def perform_muon_analysis(muon_parameters, event, telescope_id, telescope_name, 
                             mean_pixel_charge_around_ring,
                             muonpars,
                             hg_peak_sample, lg_peak_sample)
-            muon_parameters['telescope_name'].append(telescope_name)

--- a/magicctapipe/image/muons/muon_analysis.py
+++ b/magicctapipe/image/muons/muon_analysis.py
@@ -7,7 +7,7 @@ __all__ = [
 
 
 def perform_muon_analysis(muon_parameters, event, telescope_id, image, subarray,
-                          r1_dl1_calibrator_for_muon_rings, good_ring_config, event_time=np.nan,
+                          r1_dl1_calibrator_for_muon_rings, good_ring_config, telescope_type='', event_time=np.nan,
                           min_pe_for_muon_t_calc=10., data_type='mc'):
     """
 
@@ -24,6 +24,8 @@ def perform_muon_analysis(muon_parameters, event, telescope_id, image, subarray,
     r1_dl1_calibrator_for_muon_rings: `ctapipe.calib.camera.CameraCalibrator`
     good_ring_config: dict
         Set of parameters used to perform the muon ring analysis and select good rings
+    telescope_type: string
+        Telescope type identifier
     event_time: float
     min_pe_for_muon_t_calc: float
         Minimum pixel brightness used to search for the waveform maximum time
@@ -109,3 +111,4 @@ def perform_muon_analysis(muon_parameters, event, telescope_id, image, subarray,
                             mean_pixel_charge_around_ring,
                             muonpars,
                             hg_peak_sample, lg_peak_sample)
+            muon_parameters['telescope_type'].append(telescope_type)

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -87,7 +87,12 @@ class EventInfoContainer(Container):
     magic_stereo = Field(-1, 'True if both M1 and M2 are triggered')
 
 
-def mc_dl0_to_dl1(input_file, output_dir, config, muons_analysis):
+def mc_dl0_to_dl1(
+    input_file,
+    output_dir,
+    config,
+    muons_analysis=False,
+):
     """
     Processes LST-1 and MAGIC events of simtel MC DL0 data
     and computes the DL1 parameters.

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -2,9 +2,6 @@
 # coding: utf-8
 
 """
-Author: Yoshiki Ohtani (ICRR, ohtani@icrr.u-tokyo.ac.jp)
-        Muon analysis by Gabriel Emery (gabriel.emery@unige.ch)
-
 This script processes LST-1 and MAGIC events of simtel MC DL0 data (*.simtel.gz)
 and computes the DL1 parameters (i.e., Hillas, timing and leakage parameters).
 It saves only the events that all the DL1 parameters are successfully reconstructed.

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -204,6 +204,7 @@ def mc_dl0_to_dl1(input_file, output_dir, config, muons_analysis):
 
     # Configure the muon analysis:
     muon_parameters = create_muon_table()
+    muon_parameters['telescope_type'] = []
     r1_dl1_calibrator_for_muon_rings = {}
 
     if muons_analysis:
@@ -430,6 +431,7 @@ def mc_dl0_to_dl1(input_file, output_dir, config, muons_analysis):
                                           r1_dl1_calibrator_for_muon_rings=
                                           r1_dl1_calibrator_for_muon_rings[tel_id],
                                           good_ring_config=muon_config[tel_id],
+                                          telescope_type=subarray.tel[tel_id].name,
                                           data_type='mc')
 
         n_events_processed = event.count + 1

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -26,8 +26,11 @@ import numpy as np
 from pathlib import Path
 from astropy import units as u
 from astropy.table import Table
-from astropy.coordinates import AltAz, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import (
+    AltAz,
+    SkyCoord,
+    angular_separation,
+)
 from traitlets.config import Config
 from ctapipe.io import EventSource, HDF5TableWriter
 from ctapipe.core import Container, Field
@@ -42,7 +45,7 @@ from ctapipe.image import (
     leakage_parameters,
 )
 from ctapipe.instrument import SubarrayDescription
-from ctapipe.coordinates import CameraFrame, TelescopeFrame
+from ctapipe.coordinates import TelescopeFrame
 from lstchain.image.cleaning import apply_dynamic_cleaning
 from lstchain.image.modifier import (
     set_numba_seed,

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -242,7 +242,7 @@ def mc_dl0_to_dl1(
     regex_off = r'(\S+)_run(\d+)_.*_off(\S+)\.simtel.gz'
     regex = r'(\S+)_run(\d+)[_\.].*simtel.gz'
 
-    file_name = Path(input_file).resolve().name
+    file_name = Path(input_file).name
 
     if re.fullmatch(regex_off, file_name):
         parser = re.findall(regex_off, file_name)[0]
@@ -281,8 +281,8 @@ def mc_dl0_to_dl1(
                     calibrator_lst._calibrate_dl0(event, tel_id)
                     calibrator_lst._calibrate_dl1(event, tel_id)
 
-                    image = event.dl1.tel[tel_id].image
-                    peak_time = event.dl1.tel[tel_id].peak_time
+                    image = event.dl1.tel[tel_id].image.astype(np.float64)
+                    peak_time = event.dl1.tel[tel_id].peak_time.astype(np.float64)
 
                     if increase_nsb:
                         # Add noises in pixels:
@@ -316,13 +316,15 @@ def mc_dl0_to_dl1(
                     calibrator_magic._calibrate_dl0(event, tel_id)
                     calibrator_magic._calibrate_dl1(event, tel_id)
 
+                    image = event.dl1.tel[tel_id].image.astype(np.float64)
+                    peak_time = event.dl1.tel[tel_id].peak_time.astype(np.float64)
+
                     if use_charge_correction:
                         # Scale the charges of the DL1 image by the correction factor:
-                        event.dl1.tel[tel_id].image *= config_magic['charge_correction']['correction_factor']
+                        image *= config_magic['charge_correction']['correction_factor']
 
                     # Apply the image cleaning:
-                    signal_pixels, image, peak_time = magic_clean.clean_image(event.dl1.tel[tel_id].image,
-                                                                              event.dl1.tel[tel_id].peak_time)
+                    signal_pixels, image, peak_time = magic_clean.clean_image(image, peak_time)
 
                 image_cleaned = image.copy()
                 image_cleaned[~signal_pixels] = 0

--- a/magicctapipe/utils/__init__.py
+++ b/magicctapipe/utils/__init__.py
@@ -32,6 +32,7 @@ from .gti import (
 )
 
 from .functions import (
+    calculate_disp,
     calculate_impact,
     calculate_mean_direction,
     calculate_angular_distance,
@@ -89,6 +90,7 @@ __all__ = [
     "identify_time_edges",
     "intersect_time_intervals",
     "GTIGenerator",
+    "calculate_disp",
     "calculate_impact",
     "calculate_mean_direction",
     "calculate_angular_distance",


### PR DESCRIPTION
In the pull request #72 there was a confusion related to the event source which is created several times in the MC DL0 to DL1 script. This actually could make confusions again in the future when we adapt the script to the cta-process tool. Then by looking into the script I found that it is not absolutely necessary and could be more simplified. So with this pull request I refactored the code by creating the event source only once, and also with the following minor changes:

- use the CameraFrames stored in `subarray.tel[tel_id].camera.geometry.frame` instead of creating them inside the script
- modified the muon analysis modules so as not to keep the telescope names, because now in the standard analysis the name is not used
- modified the logger information display to improve the readability 

I confirmed that this pull request does not change the output results so I think I can safely merge it to the master branch. But I will keep it here a few days and so please let me know if you have any further requests or comments, especially @aleberti, @jsitarek and @gabemery. Otherwise I will merge it at the beginning of next week. Thanks! 