### PR TITLE
Refactor training/applying RFs 

### DIFF
--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -60,6 +60,8 @@ class EnergyRegressor:
 
         self.telescope_rfs.clear()
 
+        event_data.dropna(subset=self.features, inplace=True)
+
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])
 
@@ -68,7 +70,7 @@ class EnergyRegressor:
 
         for tel_id in tel_ids:
 
-            df_events = event_data.query(f'tel_id == {tel_id}').copy()
+            df_events = event_data.query(f'tel_id == {tel_id}')
 
             x_train = df_events[self.features].to_numpy()
             y_train = np.log10(df_events['true_energy'].to_numpy())
@@ -97,6 +99,8 @@ class EnergyRegressor:
         """
 
         reco_params = pd.DataFrame()
+
+        event_data.dropna(subset=self.features, inplace=True)
 
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])
@@ -196,7 +200,6 @@ class DirectionRegressor:
         self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
-
     def fit(self, event_data, tel_descriptions):
         """
         Trains RFs per telescope.
@@ -211,6 +214,8 @@ class DirectionRegressor:
 
         self.telescope_rfs.clear()
         self.tel_descriptions = tel_descriptions
+
+        event_data.dropna(subset=self.features, inplace=True)
 
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])
@@ -249,6 +254,8 @@ class DirectionRegressor:
         """
 
         reco_params = pd.DataFrame()
+
+        event_data.dropna(subset=self.features, inplace=True)
 
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])
@@ -447,6 +454,8 @@ class EventClassifier:
 
         self.telescope_rfs.clear()
 
+        event_data.dropna(subset=self.features, inplace=True)
+
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])
 
@@ -484,6 +493,8 @@ class EventClassifier:
         """
 
         reco_params = pd.DataFrame()
+
+        event_data.dropna(subset=self.features, inplace=True)
 
         if self.use_unsigned_features:
             event_data[self.features] = np.abs(event_data[self.features])

--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -8,9 +8,12 @@ import numpy as np
 import pandas as pd
 import sklearn.ensemble
 from astropy import units as u
-from astropy.coordinates import AltAz, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
-from ctapipe.coordinates import CameraFrame, TelescopeFrame
+from astropy.coordinates import (
+    AltAz,
+    SkyCoord,
+    angular_separation,
+)
+from ctapipe.coordinates import TelescopeFrame
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -284,11 +287,7 @@ class DirectionRegressor:
             )
 
             tel_frame = TelescopeFrame(telescope_pointing=tel_pointing)
-
-            camera_frame = CameraFrame(
-                focal_length=self.tel_descriptions[tel_id].optics.equivalent_focal_length,
-                rotation=self.tel_descriptions[tel_id].camera.geometry.cam_rotation,
-            )
+            camera_frame = self.tel_descriptions[tel_id].camera.geometry.frame
 
             event_coord = SkyCoord(
                 u.Quantity(df_events['x'].to_numpy(), u.m),

--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -29,7 +29,7 @@ class EnergyRegressor:
     The RFs are trained per telescope.
     """
 
-    def __init__(self, features=[], settings={}):
+    def __init__(self, features=[], settings={}, use_unsigned_features=None):
         """
         Constructor of the class.
 
@@ -39,10 +39,13 @@ class EnergyRegressor:
             Parameters used for training RFs
         settings: dict
             Settings of RF regressors
+        use_unsigned_features
+            If true, it trains RFs with unsigned features
         """
 
         self.features = features
         self.settings = settings
+        self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
     def fit(self, event_data):
@@ -57,12 +60,15 @@ class EnergyRegressor:
 
         self.telescope_rfs.clear()
 
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
+
         # Train RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
 
         for tel_id in tel_ids:
 
-            df_events = event_data.query(f'tel_id == {tel_id}')
+            df_events = event_data.query(f'tel_id == {tel_id}').copy()
 
             x_train = df_events[self.features].to_numpy()
             y_train = np.log10(df_events['true_energy'].to_numpy())
@@ -91,6 +97,9 @@ class EnergyRegressor:
         """
 
         reco_params = pd.DataFrame()
+
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
 
         # Apply trained RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
@@ -133,6 +142,7 @@ class EnergyRegressor:
         output_data = {
             'features': self.features,
             'settings': self.settings,
+            'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
         }
 
@@ -152,6 +162,7 @@ class EnergyRegressor:
 
         self.features = input_data['features']
         self.settings = input_data['settings']
+        self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
 
 
@@ -161,7 +172,12 @@ class DirectionRegressor:
     The RFs are trained per telescope.
     """
 
-    def __init__(self, features=[], settings={}):
+    def __init__(
+        self,
+        features=[],
+        settings={},
+        use_unsigned_features=None,
+    ):
         """
         Constructor of the class.
 
@@ -171,11 +187,15 @@ class DirectionRegressor:
             Parameters used for training RFs
         settings: dict
             Settings of RF regressors
+        use_unsigned_features
+            If true, it trains RFs with unsigned features
         """
 
         self.features = features
         self.settings = settings
+        self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
+
 
     def fit(self, event_data, tel_descriptions):
         """
@@ -191,6 +211,9 @@ class DirectionRegressor:
 
         self.telescope_rfs.clear()
         self.tel_descriptions = tel_descriptions
+
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
 
         # Train RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
@@ -226,6 +249,9 @@ class DirectionRegressor:
         """
 
         reco_params = pd.DataFrame()
+
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
 
         # Apply trained RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
@@ -359,6 +385,7 @@ class DirectionRegressor:
             'features': self.features,
             'settings': self.settings,
             'tel_descriptions': self.tel_descriptions,
+            'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
         }
 
@@ -379,6 +406,7 @@ class DirectionRegressor:
         self.features = input_data['features']
         self.settings = input_data['settings']
         self.tel_descriptions = input_data['tel_descriptions']
+        self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
 
 
@@ -388,7 +416,7 @@ class EventClassifier:
     The RFs are trained per telescope.
     """
 
-    def __init__(self, features=[], settings={}):
+    def __init__(self, features=[], settings={}, use_unsigned_features=None):
         """
         Constructor of the class.
 
@@ -398,10 +426,13 @@ class EventClassifier:
             Parameters used for training RFs
         settings: dict
             Settings of RF classifiers
+        use_unsigned_features
+            If true, it trains RFs with unsigned features
         """
 
         self.features = features
         self.settings = settings
+        self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
     def fit(self, event_data):
@@ -415,6 +446,9 @@ class EventClassifier:
         """
 
         self.telescope_rfs.clear()
+
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
 
         # Train RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
@@ -450,6 +484,9 @@ class EventClassifier:
         """
 
         reco_params = pd.DataFrame()
+
+        if self.use_unsigned_features:
+            event_data[self.features] = np.abs(event_data[self.features])
 
         # Apply trained RFs per telescope:
         tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
@@ -490,6 +527,7 @@ class EventClassifier:
         output_data = {
             'features': self.features,
             'settings': self.settings,
+            'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
         }
 
@@ -509,6 +547,7 @@ class EventClassifier:
 
         self.features = input_data['features']
         self.settings = input_data['settings']
+        self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
 
 

--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -180,6 +180,7 @@ class DirectionRegressor:
         self,
         features=[],
         settings={},
+        tel_descriptions={},
         use_unsigned_features=None,
     ):
         """
@@ -191,16 +192,19 @@ class DirectionRegressor:
             Parameters used for training RFs
         settings: dict
             Settings of RF regressors
+        tel_descriptions: dict
+            Telescope descriptions
         use_unsigned_features
             If true, it trains RFs with unsigned features
         """
 
         self.features = features
         self.settings = settings
+        self.tel_descriptions = tel_descriptions
         self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
-    def fit(self, event_data, tel_descriptions):
+    def fit(self, event_data):
         """
         Trains RFs per telescope.
 
@@ -208,12 +212,9 @@ class DirectionRegressor:
         ----------
         event_data: pandas.core.frame.DataFrame
             Pandas data frame of shower events
-        tel_descriptions: dict
-            Telescope descriptions
         """
 
         self.telescope_rfs.clear()
-        self.tel_descriptions = tel_descriptions
 
         event_data.dropna(subset=self.features, inplace=True)
 

--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -43,7 +43,7 @@ class EnergyRegressor:
         settings: dict
             Settings of RF regressors
         use_unsigned_features
-            If true, it trains RFs with unsigned features
+            If True, it trains RFs with unsigned features
         """
 
         self.features = features
@@ -198,7 +198,7 @@ class DirectionRegressor:
         tel_descriptions: dict
             Telescope descriptions
         use_unsigned_features
-            If true, it trains RFs with unsigned features
+            If True, it trains RFs with unsigned features
         """
 
         self.features = features
@@ -434,7 +434,7 @@ class EventClassifier:
         settings: dict
             Settings of RF classifiers
         use_unsigned_features
-            If true, it trains RFs with unsigned features
+            If True, it trains RFs with unsigned features
         """
 
         self.features = features

--- a/magicctapipe/reco/estimators.py
+++ b/magicctapipe/reco/estimators.py
@@ -32,22 +32,22 @@ class EnergyRegressor:
     The RFs are trained per telescope.
     """
 
-    def __init__(self, features=[], settings={}, use_unsigned_features=None):
+    def __init__(self, settings={}, features=[], use_unsigned_features=None):
         """
         Constructor of the class.
 
         Parameters
         ----------
-        features: list
-            Parameters used for training RFs
         settings: dict
             Settings of RF regressors
+        features: list
+            Parameters used for training RFs
         use_unsigned_features
             If True, it trains RFs with unsigned features
         """
 
-        self.features = features
         self.settings = settings
+        self.features = features
         self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
@@ -147,8 +147,8 @@ class EnergyRegressor:
         """
 
         output_data = {
-            'features': self.features,
             'settings': self.settings,
+            'features': self.features,
             'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
         }
@@ -167,8 +167,8 @@ class EnergyRegressor:
 
         input_data = joblib.load(input_file)
 
-        self.features = input_data['features']
         self.settings = input_data['settings']
+        self.features = input_data['features']
         self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
 
@@ -181,8 +181,8 @@ class DirectionRegressor:
 
     def __init__(
         self,
-        features=[],
         settings={},
+        features=[],
         tel_descriptions={},
         use_unsigned_features=None,
     ):
@@ -191,18 +191,18 @@ class DirectionRegressor:
 
         Parameters
         ----------
-        features: list
-            Parameters used for training RFs
         settings: dict
             Settings of RF regressors
+        features: list
+            Parameters used for training RFs
         tel_descriptions: dict
             Telescope descriptions
         use_unsigned_features
             If True, it trains RFs with unsigned features
         """
 
-        self.features = features
         self.settings = settings
+        self.features = features
         self.tel_descriptions = tel_descriptions
         self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
@@ -389,8 +389,8 @@ class DirectionRegressor:
         """
 
         output_data = {
-            'features': self.features,
             'settings': self.settings,
+            'features': self.features,
             'tel_descriptions': self.tel_descriptions,
             'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
@@ -410,8 +410,8 @@ class DirectionRegressor:
 
         input_data = joblib.load(input_file)
 
-        self.features = input_data['features']
         self.settings = input_data['settings']
+        self.features = input_data['features']
         self.tel_descriptions = input_data['tel_descriptions']
         self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
@@ -423,22 +423,22 @@ class EventClassifier:
     The RFs are trained per telescope.
     """
 
-    def __init__(self, features=[], settings={}, use_unsigned_features=None):
+    def __init__(self, settings={}, features=[], use_unsigned_features=None):
         """
         Constructor of the class.
 
         Parameters
         ----------
-        features: list
-            Parameters used for training RFs
         settings: dict
             Settings of RF classifiers
+        features: list
+            Parameters used for training RFs
         use_unsigned_features
             If True, it trains RFs with unsigned features
         """
 
-        self.features = features
         self.settings = settings
+        self.features = features
         self.use_unsigned_features = use_unsigned_features
         self.telescope_rfs = {}
 
@@ -536,8 +536,8 @@ class EventClassifier:
         """
 
         output_data = {
-            'features': self.features,
             'settings': self.settings,
+            'features': self.features,
             'use_unsigned_features': self.use_unsigned_features,
             'telescope_rfs': self.telescope_rfs,
         }
@@ -556,8 +556,8 @@ class EventClassifier:
 
         input_data = joblib.load(input_file)
 
-        self.features = input_data['features']
         self.settings = input_data['settings']
+        self.features = input_data['features']
         self.use_unsigned_features = input_data['use_unsigned_features']
         self.telescope_rfs = input_data['telescope_rfs']
 

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -110,6 +110,10 @@ energy_regressor:
         'impact',
     ]
 
+    gamma_offaxis:
+        min: 0.2   # unit: [deg]
+        max: 0.6   # unit: [deg]
+
 
 direction_regressor:
     settings:
@@ -142,6 +146,10 @@ direction_regressor:
         'h_max',
         'impact',
     ]
+
+    gamma_offaxis:
+        min: 0.2   # unit: [deg]
+        max: 0.6   # unit: [deg]
 
 
 event_classifier:
@@ -176,6 +184,10 @@ event_classifier:
         'h_max',
         'impact',
     ]
+
+    gamma_offaxis:
+        min: 0.2   # unit: [deg]
+        max: 0.6   # unit: [deg]
 
 
 create_irf:

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
@@ -2,9 +2,8 @@
 # coding: utf-8
 
 """
-Author: Yoshiki Ohtani (ICRR, ohtani@icrr.u-tokyo.ac.jp)
-
-This script processes DL1-stereo events and reconstructs the DL2 parameters (i.e., energy, direction and gammaness) with trained RFs.
+This script processes DL1-stereo events and reconstructs the DL2 parameters
+(i.e., energy, direction and gammaness) with trained RFs.
 The RFs are currently applied per telescope combination and per telescope type.
 
 Usage:

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
@@ -68,8 +68,6 @@ def apply_rfs(event_data, estimator):
     tel_ids = list(estimator.telescope_rfs.keys())
 
     df_events = event_data.query(f'(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})').copy()
-    df_events.dropna(subset=estimator.features, inplace=True)
-
     df_events['multiplicity'] = df_events.groupby(['obs_id', 'event_id']).size()
     df_events.query(f'multiplicity == {len(tel_ids)}', inplace=True)
 

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
@@ -13,37 +13,33 @@ $ python lst1_magic_dl1_stereo_to_dl2.py
 --output-dir ./data/dl2
 """
 
-import re
-import glob
-import time
-import logging
 import argparse
-import numpy as np
-import pandas as pd
+import glob
+import logging
+import re
+import time
 from pathlib import Path
+
+import pandas as pd
 from astropy import units as u
 from astropy.time import Time
 from ctapipe.instrument import SubarrayDescription
-from magicctapipe.reco import (
-    EnergyRegressor,
-    DirectionRegressor,
-    EventClassifier,
-)
+from magicctapipe.reco import DirectionRegressor, EnergyRegressor, EventClassifier
 from magicctapipe.utils import (
     check_tel_combination,
-    transform_altaz_to_radec,
     save_pandas_to_table,
+    transform_altaz_to_radec,
 )
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
-nsec2sec = 1e-9
+NSEC2SEC = 1e-9
 
 __all__ = [
-    'apply_rfs',
-    'dl1_stereo_to_dl2',
+    "apply_rfs",
+    "dl1_stereo_to_dl2",
 ]
 
 
@@ -66,26 +62,22 @@ def apply_rfs(event_data, estimator):
 
     tel_ids = list(estimator.telescope_rfs.keys())
 
-    df_events = event_data.query(f'(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})').copy()
-    df_events['multiplicity'] = df_events.groupby(['obs_id', 'event_id']).size()
-    df_events.query(f'multiplicity == {len(tel_ids)}', inplace=True)
+    df_events = event_data.query(
+        f"(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})"
+    ).copy()
 
-    n_events = len(df_events.groupby(['obs_id', 'event_id']).size())
+    df_events["multiplicity"] = df_events.groupby(["obs_id", "event_id"]).size()
+    df_events.query(f"multiplicity == {len(tel_ids)}", inplace=True)
 
-    if n_events > 0:
-        logger.info(f'--> {n_events} events are found. Applying...')
-        reco_params = estimator.predict(df_events)
-    else:
-        logger.warning('--> No corresponding events are found. Skipping.')
-        reco_params = pd.DataFrame()
+    reco_params = estimator.predict(df_events)
 
     return reco_params
 
 
 def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
     """
-    Processes DL1-stereo events and
-    reconstructs the DL2 parameters with trained RFs.
+    Processes DL1-stereo events and reconstructs
+    the DL2 parameters with trained RFs.
 
     Parameters
     ----------
@@ -97,25 +89,25 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         Path to a directory where to save an output DL2 data file
     """
 
-    logger.info('\nLoading the input DL1-stereo data file:')
-    logger.info(input_file_dl1)
+    logger.info(f"\nInput DL1-stereo data file:\n{input_file_dl1}")
+    logger.info(f"\nInput RF directory:\n{input_dir_rfs}")
 
-    event_data = pd.read_hdf(input_file_dl1, key='events/parameters')
-    event_data.set_index(['obs_id', 'event_id', 'tel_id'], inplace=True)
+    event_data = pd.read_hdf(input_file_dl1, key="events/parameters")
+    event_data.set_index(["obs_id", "event_id", "tel_id"], inplace=True)
     event_data.sort_index(inplace=True)
 
     check_tel_combination(event_data)
 
-    is_simulation = ('true_energy' in event_data.columns)
+    is_simulation = "true_energy" in event_data.columns
 
     # Reconstruct energy:
-    mask_energy_rf = f'{input_dir_rfs}/energy_regressor*.joblib'
+    mask_energy_rf = f"{input_dir_rfs}/energy_regressor*.joblib"
 
     input_rfs_energy = glob.glob(mask_energy_rf)
     input_rfs_energy.sort()
 
     if len(input_rfs_energy) > 0:
-        logger.info('\nReconstructing energy...')
+        logger.info("\nReconstructing energy...")
 
         reco_params = pd.DataFrame()
         energy_regressor = EnergyRegressor()
@@ -123,10 +115,9 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         for input_rfs in input_rfs_energy:
 
             logger.info(input_rfs)
-
             energy_regressor.load(input_rfs)
-            df_reco_energy = apply_rfs(event_data, energy_regressor)
 
+            df_reco_energy = apply_rfs(event_data, energy_regressor)
             reco_params = reco_params.append(df_reco_energy)
 
         event_data = event_data.join(reco_params)
@@ -134,13 +125,13 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         del energy_regressor
 
     # Reconstruct arrival directions:
-    mask_direction_rf = f'{input_dir_rfs}/direction_regressor*.joblib'
+    mask_direction_rf = f"{input_dir_rfs}/direction_regressor*.joblib"
 
     input_rfs_direction = glob.glob(mask_direction_rf)
     input_rfs_direction.sort()
 
     if len(input_rfs_direction) > 0:
-        logger.info('\nReconstructing arrival directions...')
+        logger.info("\nReconstructing arrival directions...")
 
         reco_params = pd.DataFrame()
         direction_regressor = DirectionRegressor()
@@ -148,56 +139,61 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         for input_rfs in input_rfs_direction:
 
             logger.info(input_rfs)
-
             direction_regressor.load(input_rfs)
-            df_reco_direction = apply_rfs(event_data, direction_regressor)
 
+            df_reco_direction = apply_rfs(event_data, direction_regressor)
             reco_params = reco_params.append(df_reco_direction)
 
         event_data = event_data.join(reco_params)
 
         if not is_simulation:
-            logger.info('\nTransforming the Alt/Az coordinate to the RA/Dec coordinate...')
+            logger.info(
+                "\nTransforming the Alt/Az coordinate to the RA/Dec coordinate..."
+            )
 
-            if 'timestamp' in event_data.columns:
-                timestamps = Time(event_data['timestamp'].to_numpy(), format='unix', scale='utc')
+            if "timestamp" in event_data.columns:
+                timestamps = Time(
+                    event_data["timestamp"].to_numpy(),
+                    format="unix",
+                    scale="utc",
+                )
 
             else:
-                time_sec = event_data['time_sec'].to_numpy()
-                time_nanosec = event_data['time_nanosec'].to_numpy() * nsec2sec
+                time_sec = event_data["time_sec"].to_numpy()
+                time_nanosec = event_data["time_nanosec"].to_numpy() * NSEC2SEC
 
-                timestamps = Time(time_sec + time_nanosec, format='unix', scale='utc')
+                timestamps = Time(time_sec + time_nanosec, format="unix", scale="utc")
 
-                event_data['timestamp'] = timestamps.value
-                event_data.drop(columns=['time_sec', 'time_nanosec'], inplace=True)
+                event_data["timestamp"] = timestamps.value
+                event_data.drop(columns=["time_sec", "time_nanosec"], inplace=True)
 
             pointing_ra, pointing_dec = transform_altaz_to_radec(
-                alt=u.Quantity(event_data['pointing_alt'].values, u.rad),
-                az=u.Quantity(event_data['pointing_az'].values, u.rad),
+                alt=u.Quantity(event_data["pointing_alt"].values, u.rad),
+                az=u.Quantity(event_data["pointing_az"].values, u.rad),
                 timestamp=timestamps,
             )
 
             reco_ra, reco_dec = transform_altaz_to_radec(
-                alt=u.Quantity(event_data['reco_alt'].values, u.deg),
-                az=u.Quantity(event_data['reco_az'].values, u.deg),
+                alt=u.Quantity(event_data["reco_alt"].values, u.deg),
+                az=u.Quantity(event_data["reco_az"].values, u.deg),
                 timestamp=timestamps,
             )
 
-            event_data['pointing_ra'] = pointing_ra.to(u.deg).value
-            event_data['pointing_dec'] = pointing_dec.to(u.deg).value
-            event_data['reco_ra'] = reco_ra.to(u.deg).value
-            event_data['reco_dec'] = reco_dec.to(u.deg).value
+            event_data["pointing_ra"] = pointing_ra.to(u.deg).value
+            event_data["pointing_dec"] = pointing_dec.to(u.deg).value
+            event_data["reco_ra"] = reco_ra.to(u.deg).value
+            event_data["reco_dec"] = reco_dec.to(u.deg).value
 
         del direction_regressor
 
     # Reconstruct the gammaness:
-    mask_classifier = f'{input_dir_rfs}/event_classifier*.joblib'
+    mask_classifier = f"{input_dir_rfs}/event_classifier*.joblib"
 
     input_rfs_classifier = glob.glob(mask_classifier)
     input_rfs_classifier.sort()
 
     if len(input_rfs_classifier) > 0:
-        logger.info('\nReconstructing the gammaness...')
+        logger.info("\nReconstructing the gammaness...")
 
         reco_params = pd.DataFrame()
         event_classifier = EventClassifier()
@@ -205,10 +201,9 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         for input_rfs in input_rfs_classifier:
 
             logger.info(input_rfs)
-
             event_classifier.load(input_rfs)
-            df_reco_class = apply_rfs(event_data, event_classifier)
 
+            df_reco_class = apply_rfs(event_data, event_classifier)
             reco_params = reco_params.append(df_reco_class)
 
         event_data = event_data.join(reco_params)
@@ -218,27 +213,40 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
     # Save the data in an output file:
     Path(output_dir).mkdir(exist_ok=True, parents=True)
 
-    regex = r'dl1_stereo_(\S+)\.h5'
+    regex = r"dl1_stereo_(\S+)\.h5"
     file_name = Path(input_file_dl1).name
 
     if re.fullmatch(regex, file_name):
         parser = re.findall(regex, file_name)[0]
-        output_file = f'{output_dir}/dl2_{parser}.h5'
+        output_file = f"{output_dir}/dl2_{parser}.h5"
     else:
-        raise RuntimeError('Could not parse information from the input file name.')
+        raise RuntimeError("Could not parse information from the input file name.")
 
     event_data.reset_index(inplace=True)
-    save_pandas_to_table(event_data, output_file, group_name='/events', table_name='parameters', mode='w')
+
+    save_pandas_to_table(
+        event_data,
+        output_file,
+        group_name="/events",
+        table_name="parameters",
+        mode="w",
+    )
+
+    if is_simulation:
+        sim_config = pd.read_hdf(input_file_dl1, key="simulation/config")
+
+        save_pandas_to_table(
+            sim_config,
+            output_file,
+            group_name="/simulation",
+            table_name="config",
+            mode="a",
+        )
 
     subarray = SubarrayDescription.from_hdf(input_file_dl1)
     subarray.to_hdf(output_file)
 
-    if is_simulation:
-        sim_config = pd.read_hdf(input_file_dl1, key='simulation/config')
-        save_pandas_to_table(sim_config, output_file, group_name='/simulation', table_name='config', mode='a')
-
-    logger.info('\nOutput file:')
-    logger.info(output_file)
+    logger.info(f"\nOutput file:\n{output_file}")
 
 
 def main():
@@ -248,18 +256,30 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '--input-file-dl1', '-d', dest='input_file_dl1', type=str, required=True,
-        help='Path to an input DL1-stereo data file.',
+        "--input-file-dl1",
+        "-d",
+        dest="input_file_dl1",
+        type=str,
+        required=True,
+        help="Path to an input DL1-stereo data file.",
     )
 
     parser.add_argument(
-        '--input-dir-rfs', '-r', dest='input_dir_rfs', type=str, required=True,
-        help='Path to a directory where trained RFs are stored.',
+        "--input-dir-rfs",
+        "-r",
+        dest="input_dir_rfs",
+        type=str,
+        required=True,
+        help="Path to a directory where trained RFs are stored.",
     )
 
     parser.add_argument(
-        '--output-dir', '-o', dest='output_dir', type=str, default='./data',
-        help='Path to a directory where to save an output DL2 data file.',
+        "--output-dir",
+        "-o",
+        dest="output_dir",
+        type=str,
+        default="./data",
+        help="Path to a directory where to save an output DL2 data file.",
     )
 
     args = parser.parse_args()
@@ -267,11 +287,11 @@ def main():
     # Process the input data:
     dl1_stereo_to_dl2(args.input_file_dl1, args.input_dir_rfs, args.output_dir)
 
-    logger.info('\nDone.')
+    logger.info("\nDone.")
 
     process_time = time.time() - start_time
-    logger.info(f'\nProcess time: {process_time:.0f} [sec]\n')
+    logger.info(f"\nProcess time: {process_time:.0f} [sec]\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -2,20 +2,22 @@
 # coding: utf-8
 
 """
-This script trains energy, direction regressors and event classifiers with input DL1-stereo data.
-The RFs are currently trained per telescope combination and per telescope type.
-When training event classifiers, the number of gamma MC or background samples is automatically adjusted
-so that the RFs are trained with the same number of gamma MC and background samples.
+This script trains energy, direction regressors and event classifiers with input
+DL1-stereo data. The RFs are currently trained per telescope combination and per
+telescope type. When training event classifiers, the number of gamma MC or
+background samples is automatically adjusted so that the RFs are trained with
+the same number of gamma MC and background samples.
 
-When running the script, please specify the type of RFs that will be trained by giving
-"--train-energy", "--train-direction" or "--train-classifier" arguments.
+When running the script, please specify the type of RFs that will be trained
+by giving "--train-energy", "--train-direction" or "--train-classifier" arguments.
 
-If the "--use-unsigned" argument is given, the RFs will be trained with unsigned features.
+If the "--use-unsigned" argument is given, the RFs will be trained with
+unsigned features.
 
 Usage:
 $ python lst1_magic_train_rfs.py
---input-file-gamma ./data/dl1_stereo/dl1_stereo_gamma_40deg_90deg_off0.4deg_LST-1_MAGIC_run1_to_run400.h5
---input-file-bkg ./data/dl1_stereo/dl1_stereo_proton_40deg_90deg_LST-1_MAGIC_run1_to_run4000.h5
+--input-file-gamma ./data/dl1_stereo/dl1_stereo_gamma_40deg_90deg.h5
+--input-file-bkg ./data/dl1_stereo/dl1_stereo_proton_40deg_90deg.h5
 --output-dir ./data/rfs
 --config-file ./config.yaml
 (--train-energy)
@@ -24,52 +26,53 @@ $ python lst1_magic_train_rfs.py
 (--use-unsigned)
 """
 
-import time
-import yaml
-import random
-import logging
 import argparse
+import logging
+import random
+import time
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
+import yaml
 from ctapipe.instrument import SubarrayDescription
-from magicctapipe.reco import (
-    EnergyRegressor,
-    DirectionRegressor,
-    EventClassifier,
-)
+from magicctapipe.reco import DirectionRegressor, EnergyRegressor, EventClassifier
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
+EVENT_CLASS_GAMMA = 0
+EVENT_CLASS_BKG = 1
+
+# Here event weights are set to 1, meaning no weights.
+# ToBeChecked: what weights are best for training RFs?
+EVENT_WEIGHT = 1
+
 tel_combinations = {
-    'm1_m2': [2, 3],
-    'lst1_m1': [1, 2],
-    'lst1_m2': [1, 3],
-    'lst1_m1_m2': [1, 2, 3],
+    "m1_m2": [2, 3],
+    "lst1_m1": [1, 2],
+    "lst1_m2": [1, 3],
+    "lst1_m1_m2": [1, 2, 3],
 }
 
-event_class_gamma = 0
-event_class_bkg = 1
-
-#grouped_by = ['obs_id', 'event_id'] # original
-# if files with same obs_id for different points are merged use this:
-grouped_by = ['obs_id', 'event_id', 'true_alt', 'true_az']
+# Use true Alt/Az directions for pandas index in order to classify the events
+# simulated by different pointing directions but have the same observation ID:
+group_index = ["obs_id", "event_id", "true_alt", "true_az"]
 
 __all__ = [
-    'load_train_data_file',
-    'check_feature_importance',
-    'get_events_at_random',
-    'train_energy_regressor',
-    'train_direction_regressor',
-    'train_event_classifier',
+    "load_train_data_file",
+    "check_feature_importance",
+    "get_events_at_random",
+    "train_energy_regressor",
+    "train_direction_regressor",
+    "train_event_classifier",
 ]
 
 
 def load_train_data_file(input_file, true_event_class=None):
     """
-    Loads an input DL1-stereo data file for training samples
+    Loads an input DL1-stereo data file as training samples
     and separates the events per telescope combination.
 
     Parameters
@@ -86,27 +89,28 @@ def load_train_data_file(input_file, true_event_class=None):
         per telescope combination
     """
 
-    event_data = pd.read_hdf(input_file, key='events/parameters')
-    event_data.set_index(grouped_by+['tel_id'], inplace=True)
+    event_data = pd.read_hdf(input_file, key="events/parameters")
+    event_data.set_index(group_index + ["tel_id"], inplace=True)
     event_data.sort_index(inplace=True)
 
-    if true_event_class is not None:
-        event_data['true_event_class'] = true_event_class
+    event_data["event_weight"] = EVENT_WEIGHT
 
-    # Here event weights are set to 1, meaning no weights.
-    # ToBeChecked: what weights are best for training RFs?
-    event_data['event_weight'] = 1
+    if true_event_class is not None:
+        event_data["true_event_class"] = true_event_class
 
     data_train = {}
 
     for tel_combo, tel_ids in tel_combinations.items():
 
-        df_events = event_data.query(f'(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})').copy()
-        df_events['multiplicity'] = df_events.groupby(grouped_by).size()
-        df_events.query(f'multiplicity == {len(tel_ids)}', inplace=True)
+        df_events = event_data.query(
+            f"(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})"
+        ).copy()
 
-        n_events = len(df_events.groupby(grouped_by).size())
-        logger.info(f'{tel_combo}: {n_events} events')
+        df_events["multiplicity"] = df_events.groupby(group_index).size()
+        df_events.query(f"multiplicity == {len(tel_ids)}", inplace=True)
+
+        n_events = len(df_events.groupby(group_index).size())
+        logger.info(f"{tel_combo}: {n_events} events")
 
         if n_events > 0:
             data_train[tel_combo] = df_events
@@ -124,24 +128,24 @@ def check_feature_importance(estimator):
         Trained regressor or classifier
     """
 
+    features = np.array(estimator.features)
     tel_ids = estimator.telescope_rfs.keys()
 
     for tel_id in tel_ids:
 
-        logger.info(f'Telescope {tel_id}')
+        logger.info(f"Telescope {tel_id}:")
+        telescope_rf = estimator.telescope_rfs[tel_id]
 
-        # Sort the features by the importance:
-        importances = estimator.telescope_rfs[tel_id].feature_importances_
+        importances = telescope_rf.feature_importances_
         importances_sort = np.sort(importances)[::-1]
-
-        indices = np.argsort(importances)[::-1]
-        features_sort = np.array(estimator.features)[indices]
+        indices_sort = np.argsort(importances)[::-1]
+        features_sort = features[indices_sort]
 
         for feature, importance in zip(features_sort, importances_sort):
-            logger.info(f'\t{feature}: {importance}')
+            logger.info(f"\t{feature}: {importance}")
 
 
-def get_events_at_random(event_data, n_events):
+def get_events_at_random(event_data, n_random):
     """
     Extracts a given number of events at random.
 
@@ -149,7 +153,7 @@ def get_events_at_random(event_data, n_events):
     ----------
     event_data: pandas.core.frame.DataFrame
         Pandas data frame of training samples
-    n_events:
+    n_random:
         The number of events to be extracted at random
 
     Returns
@@ -158,17 +162,16 @@ def get_events_at_random(event_data, n_events):
         Pandas data frame of the events randomly extracted
     """
 
-    group = event_data.groupby(grouped_by).size()
-    indices = random.sample(range(len(group)), n_events)
-
     data_selected = pd.DataFrame()
 
-    tel_ids = np.unique(event_data.index.get_level_values('tel_id'))
+    n_events = len(event_data.groupby(group_index).size())
+    indices = random.sample(range(n_events), n_random)
+
+    tel_ids = np.unique(event_data.index.get_level_values("tel_id"))
 
     for tel_id in tel_ids:
-        df_events = event_data.query(f'tel_id == {tel_id}').copy()
+        df_events = event_data.query(f"tel_id == {tel_id}").copy()
         df_events = df_events.iloc[indices]
-
         data_selected = data_selected.append(df_events)
 
     data_selected.sort_index(inplace=True)
@@ -197,24 +200,27 @@ def train_energy_regressor(
         If True, it uses unsigned features for training RFs
     """
 
-    logger.info(f'\nUse unsigned features: {use_unsigned_features}')
+    logger.info(f"Input file:\n{input_file}")
+    logger.info(f"\nUse unsigned features: {use_unsigned_features}")
 
     # Load the input file:
-    logger.info('\nLoading the input file:')
-    logger.info(input_file)
-
     data_train = load_train_data_file(input_file)
 
     # Configure the energy regressor:
-    config_rf = config['energy_regressor']
+    config_rf = config["energy_regressor"]
 
-    logger.info('\nRF settings:')
-    logger.info(config_rf['settings'])
+    logger.info("\nRF settings:")
+    for key, value in config_rf["settings"]:
+        logger.info(f"\t{key}: {value}")
 
-    logger.info('\nFeatures:')
-    logger.info(config_rf['features'])
+    logger.info("\nFeatures:")
+    logger.info(config_rf["features"])
 
-    energy_regressor = EnergyRegressor(config_rf['features'], config_rf['settings'], use_unsigned_features)
+    energy_regressor = EnergyRegressor(
+        config_rf["settings"],
+        config_rf["features"],
+        use_unsigned_features,
+    )
 
     # Train the regressors per telescope combination:
     Path(output_dir).mkdir(exist_ok=True, parents=True)
@@ -224,18 +230,16 @@ def train_energy_regressor(
         logger.info(f'\nTraining energy regressors for "{tel_combo}" events...')
         energy_regressor.fit(data_train[tel_combo])
 
-        logger.info('\nFeature importance:')
+        logger.info("\nFeature importance:")
         check_feature_importance(energy_regressor)
 
         if use_unsigned_features:
-            output_file = f'{output_dir}/energy_regressors_{tel_combo}_unsigned.joblib'
+            output_file = f"{output_dir}/energy_regressors_{tel_combo}_unsigned.joblib"
         else:
-            output_file = f'{output_dir}/energy_regressors_{tel_combo}.joblib'
+            output_file = f"{output_dir}/energy_regressors_{tel_combo}.joblib"
 
         energy_regressor.save(output_file)
-
-        logger.info('\nOutput file:')
-        logger.info(output_file)
+        logger.info(f"\nOutput file:\n{output_file}")
 
 
 def train_direction_regressor(
@@ -259,29 +263,28 @@ def train_direction_regressor(
         If True, it uses unsigned features for training RFs
     """
 
-    logger.info(f'\nUse unsigned features: {use_unsigned_features}')
+    logger.info(f"Input file:\n{input_file}")
+    logger.info(f"\nUse unsigned features: {use_unsigned_features}")
 
     # Load the input file:
-    logger.info('\nLoading the input file:')
-    logger.info(input_file)
-
     data_train = load_train_data_file(input_file)
 
     subarray = SubarrayDescription.from_hdf(input_file)
     tel_descriptions = subarray.tel
 
     # Configure the direction regressor:
-    config_rf = config['direction_regressor']
+    config_rf = config["direction_regressor"]
 
-    logger.info('\nRF settings:')
-    logger.info(config_rf['settings'])
+    logger.info("\nRF settings:")
+    for key, value in config_rf["settings"]:
+        logger.info(f"\t{key}: {value}")
 
-    logger.info('\nFeatures:')
-    logger.info(config_rf['features'])
+    logger.info("\nFeatures:")
+    logger.info(config_rf["features"])
 
     direction_regressor = DirectionRegressor(
-        config_rf['features'],
-        config_rf['settings'],
+        config_rf["settings"],
+        config_rf["features"],
         tel_descriptions,
         use_unsigned_features,
     )
@@ -294,18 +297,18 @@ def train_direction_regressor(
         logger.info(f'\nTraining direction regressors for "{tel_combo}" events...')
         direction_regressor.fit(data_train[tel_combo])
 
-        logger.info('\nFeature importance:')
+        logger.info("\nFeature importance:")
         check_feature_importance(direction_regressor)
 
         if use_unsigned_features:
-            output_file = f'{output_dir}/direction_regressors_{tel_combo}_unsigned.joblib'
+            output_file = (
+                f"{output_dir}/direction_regressors_{tel_combo}_unsigned.joblib"
+            )
         else:
-            output_file = f'{output_dir}/direction_regressors_{tel_combo}.joblib'
+            output_file = f"{output_dir}/direction_regressors_{tel_combo}.joblib"
 
         direction_regressor.save(output_file)
-
-        logger.info('\nOutput file:')
-        logger.info(output_file)
+        logger.info(f"\nOutput file:\n{output_file}")
 
 
 def train_event_classifier(
@@ -332,29 +335,29 @@ def train_event_classifier(
         If True, it uses unsigned features for training RFs
     """
 
-    logger.info(f'\nUse unsigned features: {use_unsigned_features}')
+    logger.info(f"Input gamma MC data file:\n{input_file_gamma}")
+    logger.info(f"Input background data file:\n{input_file_bkg}")
+    logger.info(f"\nUse unsigned features: {use_unsigned_features}")
 
     # Load the input files:
-    logger.info('\nLoading the input gamma MC data file:')
-    logger.info(input_file_gamma)
-
-    data_gamma = load_train_data_file(input_file_gamma, event_class_gamma)
-
-    logger.info('\nLoading the input background data file:')
-    logger.info(input_file_bkg)
-
-    data_bkg = load_train_data_file(input_file_bkg, event_class_bkg)
+    data_gamma = load_train_data_file(input_file_gamma, EVENT_CLASS_GAMMA)
+    data_bkg = load_train_data_file(input_file_bkg, EVENT_CLASS_BKG)
 
     # Configure the event classifier:
-    config_rf = config['event_classifier']
+    config_rf = config["event_classifier"]
 
-    logger.info('\nRF settings:')
-    logger.info(config_rf['settings'])
+    logger.info("\nRF settings:")
+    for key, value in config_rf["settings"]:
+        logger.info(f"\t{key}: {value}")
 
-    logger.info('\nFeatures:')
-    logger.info(config_rf['features'])
+    logger.info("\nFeatures:")
+    logger.info(config_rf["features"])
 
-    event_classifier = EventClassifier(config_rf['features'], config_rf['settings'], use_unsigned_features)
+    event_classifier = EventClassifier(
+        config_rf["settings"],
+        config_rf["features"],
+        use_unsigned_features,
+    )
 
     # Train the classifiers per telescope combination:
     Path(output_dir).mkdir(exist_ok=True, parents=True)
@@ -365,35 +368,37 @@ def train_event_classifier(
 
         logger.info(f'\nTraining event classifiers for "{tel_combo}" events...')
 
-        n_events_gamma = len(data_gamma[tel_combo].groupby(grouped_by).size())
-        n_events_bkg = len(data_bkg[tel_combo].groupby(grouped_by).size())
+        n_events_gamma = len(data_gamma[tel_combo].groupby(group_index).size())
+        n_events_bkg = len(data_bkg[tel_combo].groupby(group_index).size())
 
         # Adjust the number of training samples:
         if n_events_gamma > n_events_bkg:
-            data_gamma[tel_combo] = get_events_at_random(data_gamma[tel_combo], n_events_bkg)
-            n_events_gamma = len(data_gamma[tel_combo].groupby(grouped_by).size())
+            logger.info(f"Number of gamma MC events is adjusted to {n_events_bkg}")
+            data_gamma[tel_combo] = get_events_at_random(
+                data_gamma[tel_combo],
+                n_events_bkg,
+            )
 
         elif n_events_bkg > n_events_gamma:
-            data_bkg[tel_combo] = get_events_at_random(data_bkg[tel_combo], n_events_gamma)
-            n_events_bkg = len(data_bkg[tel_combo].groupby(grouped_by).size())
-
-        logger.info(f'--> n_events_gamma = {n_events_gamma}, n_events_bkg = {n_events_bkg}')
+            logger.info(f"Number of background events is adjusted to {n_events_gamma}")
+            data_bkg[tel_combo] = get_events_at_random(
+                data_bkg[tel_combo],
+                n_events_gamma,
+            )
 
         data_train = data_gamma[tel_combo].append(data_bkg[tel_combo])
         event_classifier.fit(data_train)
 
-        logger.info('\nFeature importance:')
+        logger.info("\nFeature importance:")
         check_feature_importance(event_classifier)
 
         if use_unsigned_features:
-            output_file = f'{output_dir}/event_classifiers_{tel_combo}_unsigned.joblib'
+            output_file = f"{output_dir}/event_classifiers_{tel_combo}_unsigned.joblib"
         else:
-            output_file = f'{output_dir}/event_classifiers_{tel_combo}.joblib'
+            output_file = f"{output_dir}/event_classifiers_{tel_combo}.joblib"
 
         event_classifier.save(output_file)
-
-        logger.info('\nOutput file:')
-        logger.info(output_file)
+        logger.info(f"\nOutput file:\n{output_file}")
 
 
 def main():
@@ -403,65 +408,105 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '--input-file-gamma', '-g', dest='input_file_gamma', type=str, required=True,
-        help='Path to an input DL1-stereo gamma MC data file.',
+        "--input-file-gamma",
+        "-g",
+        dest="input_file_gamma",
+        type=str,
+        required=True,
+        help="Path to an input DL1-stereo gamma MC data file.",
     )
 
     parser.add_argument(
-        '--input-file-bkg', '-b', dest='input_file_bkg', type=str, default=None,
-        help='Path to an input DL1-stereo background data file.',
+        "--input-file-bkg",
+        "-b",
+        dest="input_file_bkg",
+        type=str,
+        default=None,
+        help="Path to an input DL1-stereo background data file.",
     )
 
     parser.add_argument(
-        '--output-dir', '-o', dest='output_dir', type=str, default='./data',
-        help='Path to a directory where to save trained RFs.',
+        "--output-dir",
+        "-o",
+        dest="output_dir",
+        type=str,
+        default="./data",
+        help="Path to a directory where to save trained RFs.",
     )
 
     parser.add_argument(
-        '--config-file', '-c', dest='config_file', type=str, default='./config.yaml',
-        help='Path to a yaml configuration file.',
+        "--config-file",
+        "-c",
+        dest="config_file",
+        type=str,
+        default="./config.yaml",
+        help="Path to a yaml configuration file.",
     )
 
     parser.add_argument(
-        '--train-energy', dest='train_energy', action='store_true',
-        help='Train energy regressors.',
+        "--train-energy",
+        dest="train_energy",
+        action="store_true",
+        help="Train energy regressors.",
     )
 
     parser.add_argument(
-        '--train-direction', dest='train_direction', action='store_true',
-        help='Train direction regressors.',
+        "--train-direction",
+        dest="train_direction",
+        action="store_true",
+        help="Train direction regressors.",
     )
 
     parser.add_argument(
-        '--train-classifier', dest='train_classifier', action='store_true',
-        help='Train event classifiers.',
+        "--train-classifier",
+        dest="train_classifier",
+        action="store_true",
+        help="Train event classifiers.",
     )
 
     parser.add_argument(
-        '--use-unsigned', dest='use_unsigned', action='store_true',
-        help='Use unsigned features for training RFs.',
+        "--use-unsigned",
+        dest="use_unsigned",
+        action="store_true",
+        help="Use unsigned features for training RFs.",
     )
 
     args = parser.parse_args()
 
-    with open(args.config_file, 'rb') as f:
+    with open(args.config_file, "rb") as f:
         config = yaml.safe_load(f)
 
     # Train RFs:
     if args.train_energy:
-        train_energy_regressor(args.input_file_gamma, args.output_dir, config, args.use_unsigned)
+        train_energy_regressor(
+            args.input_file_gamma,
+            args.output_dir,
+            config,
+            args.use_unsigned,
+        )
 
     if args.train_direction:
-        train_direction_regressor(args.input_file_gamma, args.output_dir, config, args.use_unsigned)
+        train_direction_regressor(
+            args.input_file_gamma,
+            args.output_dir,
+            config,
+            args.use_unsigned,
+        )
 
     if args.train_classifier:
-        train_event_classifier(args.input_file_gamma, args.input_file_bkg, args.output_dir, config, args.use_unsigned)
+        train_event_classifier(
+            args.input_file_gamma,
+            args.input_file_bkg,
+            args.output_dir,
+            config,
+            args.use_unsigned,
+        )
 
-    logger.info('\nDone.')
+    logger.info("\nDone.")
 
     process_time = time.time() - start_time
-    logger.info(f'\nProcess time: {process_time:.0f} [sec]\n')
+    logger.info(f"\nProcess time: {process_time:.0f} [sec]\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -275,7 +275,12 @@ def train_direction_regressor(
     tel_descriptions = subarray.tel
 
     # Configure the direction regressor:
-    direction_regressor = DirectionRegressor(config_rf['features'], config_rf['settings'], use_unsigned_features)
+    direction_regressor = DirectionRegressor(
+        config_rf['features'],
+        config_rf['settings'],
+        tel_descriptions,
+        use_unsigned_features,
+    )
 
     # Train the regressors per telescope combination:
     Path(output_dir).mkdir(exist_ok=True, parents=True)
@@ -283,7 +288,7 @@ def train_direction_regressor(
     for tel_combo in data_train.keys():
 
         logger.info(f'\nTraining direction regressors for "{tel_combo}" events...')
-        direction_regressor.fit(data_train[tel_combo], tel_descriptions)
+        direction_regressor.fit(data_train[tel_combo])
 
         logger.info('\nFeature importance:')
         check_feature_importance(direction_regressor)

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -199,12 +199,6 @@ def train_energy_regressor(
 
     logger.info(f'\nUse unsigned features: {use_unsigned_features}')
 
-    config_rf = config['energy_regressor']
-
-    logger.info('\nConfiguration for training energy regressors:')
-    for key, value in config_rf.items():
-        logger.info(f'{key}: {value}')
-
     # Load the input file:
     logger.info('\nLoading the input file:')
     logger.info(input_file)
@@ -212,6 +206,14 @@ def train_energy_regressor(
     data_train = load_train_data_file(input_file)
 
     # Configure the energy regressor:
+    config_rf = config['energy_regressor']
+
+    logger.info('\nRF settings:')
+    logger.info(config_rf['settings'])
+
+    logger.info('\nFeatures:')
+    logger.info(config_rf['features'])
+
     energy_regressor = EnergyRegressor(config_rf['features'], config_rf['settings'], use_unsigned_features)
 
     # Train the regressors per telescope combination:
@@ -259,12 +261,6 @@ def train_direction_regressor(
 
     logger.info(f'\nUse unsigned features: {use_unsigned_features}')
 
-    config_rf = config['direction_regressor']
-
-    logger.info('\nConfiguration for training direction regressors:')
-    for key, value in config_rf.items():
-        logger.info(f'{key}: {value}')
-
     # Load the input file:
     logger.info('\nLoading the input file:')
     logger.info(input_file)
@@ -275,6 +271,14 @@ def train_direction_regressor(
     tel_descriptions = subarray.tel
 
     # Configure the direction regressor:
+    config_rf = config['direction_regressor']
+
+    logger.info('\nRF settings:')
+    logger.info(config_rf['settings'])
+
+    logger.info('\nFeatures:')
+    logger.info(config_rf['features'])
+
     direction_regressor = DirectionRegressor(
         config_rf['features'],
         config_rf['settings'],
@@ -330,12 +334,6 @@ def train_event_classifier(
 
     logger.info(f'\nUse unsigned features: {use_unsigned_features}')
 
-    config_rf = config['event_classifier']
-
-    logger.info('\nConfiguration for training event classifiers:')
-    for key, value in config_rf.items():
-        logger.info(f'{key}: {value}')
-
     # Load the input files:
     logger.info('\nLoading the input gamma MC data file:')
     logger.info(input_file_gamma)
@@ -348,6 +346,14 @@ def train_event_classifier(
     data_bkg = load_train_data_file(input_file_bkg, event_class_bkg)
 
     # Configure the event classifier:
+    config_rf = config['event_classifier']
+
+    logger.info('\nRF settings:')
+    logger.info(config_rf['settings'])
+
+    logger.info('\nFeatures:')
+    logger.info(config_rf['features'])
+
     event_classifier = EventClassifier(config_rf['features'], config_rf['settings'], use_unsigned_features)
 
     # Train the classifiers per telescope combination:

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -2,15 +2,15 @@
 # coding: utf-8
 
 """
-Author: Yoshiki Ohtani (ICRR, ohtani@icrr.u-tokyo.ac.jp)
-
 This script trains energy, direction regressors and event classifiers with input DL1-stereo data.
 The RFs are currently trained per telescope combination and per telescope type.
 When training event classifiers, the number of gamma MC or background samples is automatically adjusted
 so that the RFs are trained with the same number of gamma MC and background samples.
 
-When running the script, please specify the type of RFs that you want to train by giving
+When running the script, please specify the type of RFs that will be trained by giving
 "--train-energy", "--train-direction" or "--train-classifier" arguments.
+
+If the "--use-unsigned" argument is given, the RFs will be trained with unsigned features.
 
 Usage:
 $ python lst1_magic_train_rfs.py
@@ -21,6 +21,7 @@ $ python lst1_magic_train_rfs.py
 (--train-energy)
 (--train-direction)
 (--train-classifier)
+(--use-unsigned)
 """
 
 import time

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -67,7 +67,7 @@ __all__ = [
 ]
 
 
-def load_train_data_file(input_file, features, true_event_class=None):
+def load_train_data_file(input_file, true_event_class=None):
     """
     Loads an input DL1-stereo data file for training samples
     and separates the events per telescope combination.
@@ -76,8 +76,6 @@ def load_train_data_file(input_file, features, true_event_class=None):
     ----------
     input_file: str
         Path to an input DL1-stereo data file
-    features: list
-        Parameters used for training RFs
     true_event_class: int
         True event class of input events
 
@@ -104,8 +102,6 @@ def load_train_data_file(input_file, features, true_event_class=None):
     for tel_combo, tel_ids in tel_combinations.items():
 
         df_events = event_data.query(f'(tel_id == {tel_ids}) & (multiplicity == {len(tel_ids)})').copy()
-        df_events.dropna(subset=features, inplace=True)
-
         df_events['multiplicity'] = df_events.groupby(grouped_by).size()
         df_events.query(f'multiplicity == {len(tel_ids)}', inplace=True)
 
@@ -213,7 +209,7 @@ def train_energy_regressor(
     logger.info('\nLoading the input file:')
     logger.info(input_file)
 
-    data_train = load_train_data_file(input_file, config_rf['features'])
+    data_train = load_train_data_file(input_file)
 
     # Configure the energy regressor:
     energy_regressor = EnergyRegressor(config_rf['features'], config_rf['settings'], use_unsigned_features)
@@ -273,7 +269,7 @@ def train_direction_regressor(
     logger.info('\nLoading the input file:')
     logger.info(input_file)
 
-    data_train = load_train_data_file(input_file, config_rf['features'])
+    data_train = load_train_data_file(input_file)
 
     subarray = SubarrayDescription.from_hdf(input_file)
     tel_descriptions = subarray.tel
@@ -339,12 +335,12 @@ def train_event_classifier(
     logger.info('\nLoading the input gamma MC data file:')
     logger.info(input_file_gamma)
 
-    data_gamma = load_train_data_file(input_file_gamma, config_rf['features'], event_class_gamma)
+    data_gamma = load_train_data_file(input_file_gamma, event_class_gamma)
 
     logger.info('\nLoading the input background data file:')
     logger.info(input_file_bkg)
 
-    data_bkg = load_train_data_file(input_file_bkg, config_rf['features'], event_class_bkg)
+    data_bkg = load_train_data_file(input_file_bkg, event_class_bkg)
 
     # Configure the event classifier:
     event_classifier = EventClassifier(config_rf['features'], config_rf['settings'], use_unsigned_features)

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -116,7 +116,7 @@ def load_train_data_file(input_file, true_event_class=None):
 
 def check_feature_importance(estimator):
     """
-    Checks the feature importance of trained RFs:
+    Checks the feature importance of trained RFs.
 
     Parameters
     ----------
@@ -158,8 +158,8 @@ def get_events_at_random(event_data, n_events):
         Pandas data frame of the events randomly extracted
     """
 
-    group_size = event_data.groupby(grouped_by).size()
-    indices = random.sample(range(len(group_size)), n_events)
+    group = event_data.groupby(grouped_by).size()
+    indices = random.sample(range(len(group)), n_events)
 
     data_selected = pd.DataFrame()
 


### PR DESCRIPTION
The main purpose of this pull request was to implement an option to use unsigned features for training/applying RFs, but at the same time I refactored the code a bit. Here is a briefly summary of the changes that I did:

- Added the option "--use-unsigned" with which unsigned features are used for training and applying RFs.
- Drop NaN values from an input data frame inside the estimator modules, instead of doing it in the load functions.
- Use the CameraFrame stored in a subarray instead of creating it inside the DirectionEstimator
- Changed the argument name of lst1_magic_dl1_stereo_to_dl1.py, from `--input-file` to `--input-file-dl1`
- Changed the logger information display

Any comments are very welcome.
