### PR TITLE
Fix the problem of installing the software with a Max OS

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - sphinx_rtd_theme
   - tqdm
   - traitlets
+  - uproot~=4.1
   - vitables
   - wheel
   - xz
@@ -51,6 +52,5 @@ dependencies:
   - pip:
       - lstchain~=0.9.6
       - ctapipe_io_magic~=0.4.5
-      - uproot~=4.1
       - ctaplot~=0.5.5
       - pyirf~=0.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,16 +2,16 @@
 name: magic-lst1
 channels:
   - default
-  - cta-observatory
+  - conda-forge
 dependencies:
   - python=3.7
   - pip
   - astropy
   - black
   - bokeh=1.0
-  - conda-forge::nbsphinx
-  - conda-forge::ctapipe=0.12
-  - conda-forge::gammapy=0.19.0
+  - nbsphinx
+  - ctapipe=0.12
+  - gammapy=0.19.0
   - cython
   - graphviz
   - h5py
@@ -46,8 +46,8 @@ dependencies:
   - xz
   - zlib
   - zstandard
-  - conda-forge::eventio>=1.5.0
-  - conda-forge::corsikaio
+  - eventio>=1.5.0
+  - corsikaio
   - pip:
       - lstchain~=0.9.6
       - ctapipe_io_magic~=0.4.5

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - numpydoc
   - pandas
   - pre-commit
+  - protozfits=2.0
   - psutil
   - pytables
   - pytest


### PR DESCRIPTION
Installing the software in my local Mac OS failed due to a problem of installing protozfits with pip. It was solved by installing the module with conda before installing lstchain with pip. Also, I cleaned up the environment.yml file a bit as follows:

- Remove the cta-observatory channel and instead add conda-forge channel, and then clean some lines
- Install uproot with conda instead of pip, because it is available from conda-forge

I think this changes do not harm installations for other systems. I wanted to try it just in case for linux, but now the IT container is not accessible..  I assign @aleberti for a reviewer so it would be great if you could have a look at them and merge this if it is OK for you. Thanks!