### PR TITLE
Fix the stereo reconstruction for any 2 tel events

### DIFF
--- a/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
@@ -199,10 +199,6 @@ def stereo_reconstruction(
     # Configure the HillasReconstructor:
     hillas_reconstructor = HillasReconstructor(subarray)
 
-    # Since the reconstructor requires the ArrayEventContainer as an input,
-    # here we initialize it and reset necessary information event-by-event:
-    event = ArrayEventContainer()
-
     # Start processing the events:
     logger.info("\nReconstructing the stereo parameters...")
 
@@ -216,6 +212,8 @@ def stereo_reconstruction(
     event_ids = group.index.get_level_values("event_id")
 
     for i_evt, (obs_id, event_id) in enumerate(zip(obs_ids, event_ids)):
+
+        event = ArrayEventContainer()
 
         if i_evt % 100 == 0:
             logger.info(f"{i_evt} events")


### PR DESCRIPTION
This pull request fixes the critical issue #92 happened when reconstructing any2 tel events, which used the Hillas parameters of the previous event by mistake. Now the ArrayEventContainer is initialized every time inside the event loop, so the previous event information is safely cleaned. This closes #92. 