### PR TITLE
Fix the regex to get the primary ID

### DIFF
--- a/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_mc_dl0_to_dl1.py
@@ -231,7 +231,7 @@ def mc_dl0_to_dl1(input_file, output_dir, config):
     sim_config = event_source.simulation_config
     corsika_inputcard = event_source.file_.corsika_inputcards[0].decode()
 
-    regex = r".*\nPRMPAR\s+(\d)\s+.*"
+    regex = r".*\nPRMPAR\s+(\d+)\s+.*"
     primary_id = int(re.findall(regex, corsika_inputcard)[0])
     particle = primary_particles[primary_id]
 


### PR DESCRIPTION
It is already fixed in the open pull request #91, but for people whose use the master branch, let me fix also the master branch. There is an issue on the regex to read the primary ID of a MC file for proton and helium.