### PR TITLE
Update the required version of ctapipe_io_magic

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -51,6 +51,6 @@ dependencies:
   - corsikaio
   - pip:
       - lstchain~=0.9.6
-      - ctapipe_io_magic~=0.4.5
+      - ctapipe_io_magic~=0.4.6
       - ctaplot~=0.5.5
       - pyirf~=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'astropy>=4.0.5,<5',
         'lstchain~=0.9.6',
         'ctapipe~=0.12.0',
-        'ctapipe_io_magic~=0.4.5',
+        'ctapipe_io_magic~=0.4.6',
         'ctaplot~=0.5.5',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.19.0',


### PR DESCRIPTION
This pull request updates the required version of ctapipe_io_magic from v0.4.5 to v0.4.6, which is adapted for MAGIC-mono real data.