### PR TITLE
Remove unnecessary for loop in `save_pandas_data_in_table`

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -476,7 +476,7 @@ def load_train_data_files(
 
     logger.info(
         f"\nMinimum off-axis angle allowed: {offaxis_min}"
-        f"\nMaximum off-axis angle allowed: {offaxis_min}"
+        f"\nMaximum off-axis angle allowed: {offaxis_max}"
     )
 
     if offaxis_min is not None:
@@ -927,13 +927,15 @@ def load_irf_files(input_dir_irf):
     return irf_data, extra_header
 
 
-def save_pandas_data_in_table(data, output_file, group_name, table_name, mode="w"):
+def save_pandas_data_in_table(
+    input_data, output_file, group_name, table_name, mode="w"
+):
     """
     Saves a pandas data frame in a table.
 
     Parameters
     ----------
-    data: pandas.core.frame.DataFrame
+    input_data: pandas.core.frame.DataFrame
         Pandas data frame
     output_file: str
         Path to an output HDF file
@@ -947,13 +949,10 @@ def save_pandas_data_in_table(data, output_file, group_name, table_name, mode="w
         "a" for appending the table to the file
     """
 
-    params = data.dtypes.index
-    dtypes = data.dtypes.values
+    values = [tuple(array) for array in input_data.to_numpy()]
+    dtypes = np.dtype(list(zip(input_data.dtypes.index, input_data.dtypes.values)))
 
-    data_array = np.array(
-        [tuple(array) for array in data.to_numpy()],
-        dtype=np.dtype([(param, dtype) for param, dtype in zip(params, dtypes)]),
-    )
+    data_array = np.array(values, dtype=dtypes)
 
     with tables.open_file(output_file, mode=mode) as f_out:
         f_out.create_table(group_name, table_name, createparents=True, obj=data_array)

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
@@ -404,7 +404,7 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         sim_config = pd.read_hdf(input_file_dl1, key="simulation/config")
 
         save_pandas_data_in_table(
-            data=sim_config,
+            input_data=sim_config,
             output_file=output_file,
             group_name="/simulation",
             table_name="config",

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_stereo_reco.py
@@ -322,7 +322,7 @@ def stereo_reconstruction(input_file, output_dir, config, magic_only_analysis=Fa
         sim_config = pd.read_hdf(input_file, key="simulation/config")
 
         save_pandas_data_in_table(
-            data=sim_config,
+            input_data=sim_config,
             output_file=output_file,
             group_name="/simulation",
             table_name="config",


### PR DESCRIPTION
This pull request removes the unnecessary for loop in the `magicctapipe.io. save_pandas_data_in_table` function. It also changes the argument name from `data` to `input_data`, and adapts the scripts to use the new name.