### PR TITLE
fixed two problems that prevented DL3 generation

### DIFF
--- a/magicctapipe/io/gadf.py
+++ b/magicctapipe/io/gadf.py
@@ -133,10 +133,10 @@ def create_event_hdu(
 
     # Get the instruments used for the observation
     combo_types_unique = np.unique(event_table["combo_type"])
-    tel_combos = np.array(list(TEL_COMBINATIONS.keys()))[combo_types_unique]
+    tel_combos = np.array(list(TEL_COMBINATIONS.keys()))[combo_types_unique.astype(int)]
 
     tel_list = np.unique([tel_combo.split("_") for tel_combo in tel_combos])
-    instrument = "_".join(tel_list).upper()
+    instrument = "_".join(str(tel_list)).upper()
 
     # Transfer the RA/Dec directions to the galactic coordinate
     event_coords = SkyCoord(

--- a/magicctapipe/io/gadf.py
+++ b/magicctapipe/io/gadf.py
@@ -133,10 +133,12 @@ def create_event_hdu(
 
     # Get the instruments used for the observation
     combo_types_unique = np.unique(event_table["combo_type"])
-    tel_combos = np.array(list(TEL_COMBINATIONS.keys()))[combo_types_unique.astype(int)]
+    tel_combos = np.array(list(TEL_COMBINATIONS.keys()))[combo_types_unique]
 
-    tel_list = np.unique([tel_combo.split("_") for tel_combo in tel_combos])
-    instrument = "_".join(str(tel_list)).upper()
+    tel_list = [tel_combo.split("_") for tel_combo in tel_combos]
+    tel_list_unique = np.unique(sum(tel_list, []))
+
+    instrument = "_".join(tel_list_unique).upper()
 
     # Transfer the RA/Dec directions to the galactic coordinate
     event_coords = SkyCoord(

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -136,6 +136,9 @@ def get_stereo_events(
 
         event_data_stereo.loc[df_events.index, "combo_type"] = combo_type
 
+    # Convert the combo_type from float to int
+    event_data_stereo = event_data_stereo.astype({"combo_type": int})
+
     return event_data_stereo
 
 


### PR DESCRIPTION
1) tel_combo was read as a float but used a index, and required cast to int this is a bit dangerous but it seems to be only used for the metadata 
2) list of telescopes was passed as an array, but instead should be a string

@YoshikiOhtani can you have a look?
the first problem actually would be better to be solved already earlier: saving those combinations as int and not float