### PR TITLE
Update magic mc treatment

### DIFF
--- a/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
@@ -119,13 +119,8 @@ def magic_calib_to_dl1(
         f"\nIs SUM trigger: {is_sum_trigger}"
     )
 
-    if is_simulation and not is_stereo_trigger:
-        logger.info("\nMono trigger MC data is not yet supported. Exiting...")
-        sys.exit()
-
     if is_sum_trigger:
-        logger.info("\nSUM trigger data is not yet fully supported. Exiting...")
-        sys.exit()
+        logger.warning("\nSUM trigger data is supported, but MaTaJu cleaning is not implemented.")
 
     if not is_simulation:
 

--- a/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
@@ -154,13 +154,6 @@ def magic_calib_to_dl1(
     # Configure the MAGIC image cleaning
     config_clean = config["MAGIC"]["magic_clean"]
 
-    if is_simulation and config_clean["find_hotpixels"]:
-        logger.warning(
-            "\nWARNING: Hot pixels do not exist in a simulation. "
-            "Setting the 'find_hotpixels' option to False..."
-        )
-        config_clean.update({"find_hotpixels": False})
-
     logger.info("\nMAGIC image cleaning:")
     for key, value in config_clean.items():
         logger.info(f"\t{key}: {value}")

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'astropy>=4.0.5,<5',
         'lstchain~=0.9.6',
         'ctapipe~=0.12.0',
-        'ctapipe_io_magic~=0.4.6',
+        'ctapipe_io_magic~=0.4.7',
         'ctaplot~=0.5.5',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.19.0',


### PR DESCRIPTION
This PR updates the treatment of MAGIC MC data, since there are bad pixels (pixel 0, a know feature of MAGIC simulation) and hot pixels (outliers in charge). For this, `ctapipe-io-magic` version has been updated.

Also, now mono and SumT data are fully supported. For the latter, MaTaJu cleaning implementation is still missing, so a warning is thrown. 