### PR TITLE
Remove the allow mono trigger option

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -51,6 +51,6 @@ dependencies:
   - corsikaio
   - pip:
       - lstchain~=0.9.6
-      - ctapipe_io_magic~=0.4.6
+      - ctapipe_io_magic~=0.4.7
       - ctaplot~=0.5.5
       - pyirf~=0.6.0

--- a/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
+++ b/magicctapipe/scripts/lst1_magic/magic_calib_to_dl1.py
@@ -101,13 +101,13 @@ def magic_calib_to_dl1(input_file, output_dir, config, process_run=False):
     tel_id = event_source.telescope
 
     logger.info(f"\nObservation ID: {obs_id}")
-    logger.info(f"\nTelescope ID: {tel_id}")
+    logger.info(f"Telescope ID: {tel_id}")
 
     is_stereo_trigger = event_source.is_stereo
     is_sum_trigger = event_source.is_sumt
 
-    logger.info(f"\n\nIs stereo trigger: {is_stereo_trigger}")
-    logger.info(f"\nIs SUM trigger: {is_sum_trigger}")
+    logger.info(f"\nIs stereo trigger: {is_stereo_trigger}")
+    logger.info(f"Is SUM trigger: {is_sum_trigger}")
 
     if is_sum_trigger:
         logger.warning(


### PR DESCRIPTION
This pull request removes the `--allow-mono` option from the script `magic_calib_to_dl1.py`. It was introduced not to process the mono-trigger data unexpectedly, since we do not know the trigger settings from file names, but I found another way to remove them so it is not needed now. @aleberti just in case, does this change affect the pull request about the Hillas image comparison? 