### PR TITLE
Merge only the subrun files that both M1 and M2 exist

### DIFF
--- a/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
+++ b/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
@@ -167,9 +167,9 @@ def merge_hdf_files(input_dir, output_dir=None, run_wise=False, subrun_wise=Fals
     if len(file_names_unique) == 1:
         output_file_name = file_names_unique[0]
 
-    elif file_names_unique.tolist() == ["dl1_M1", "dl1_M2"]:
+    elif file_names_unique.tolist() == ["dl1_M1.Run", "dl1_M2.Run"]:
         # Assume that the input files are telescope-wise MAGIC DL1 data
-        output_file_name = "dl1_MAGIC"
+        output_file_name = "dl1_MAGIC.Run"
 
     else:
         raise RuntimeError("Multiple types of files are found in the input directory.")

--- a/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
+++ b/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
@@ -172,7 +172,7 @@ def merge_hdf_files(input_dir, output_dir=None, run_wise=False, subrun_wise=Fals
         output_file_name = "dl1_MAGIC"
 
     else:
-        RuntimeError("Multiple types of files are found in the input directory.")
+        raise RuntimeError("Multiple types of files are found in the input directory.")
 
     # Merge the input files
     run_ids_unique = np.unique(run_ids)


### PR DESCRIPTION
With this pull request I changed the functionality of the `merge_hdu_files.py` script when the `--subrun-wise` option is used. Originally, even if either M1 or M2 subrun file of a given subrun ID is missing, the script processes the file and changed its name as if both M1 and M2 files exist. Here is the example of what I meant:

> data/dl1/dl1_M1.Run05096367.011.h5
> data/dl1/dl1_M2.Run05096367.011.h5
> --> Output file: data/dl1/merged/dl1_MAGIC.Run05096367.011.h5
> 
> data/dl1/dl1_M1.Run05096367.012.h5
> --> Output file: data/dl1/merged/dl1_MAGIC.Run05096367.012.h5

Now, with this script the subrun ID that either M1 or M2 subrun file is missing is skipped. If one wants to merge the file, either `--run-wise` option or simply running without any options can be used.