### PR TITLE
Fix the issue when creating an event list HDU

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -178,6 +178,7 @@ def get_dl2_mean(event_data, weight_type="simple", group_index=["obs_id", "event
         params = ["combo_type", "multiplicity", "timestamp"]
 
     event_data_mean = event_data[params].groupby(group_index).mean()
+    event_data_mean = event_data_mean.astype({"combo_type": int, "multiplicity": int})
 
     # Calculate the mean pointing direction
     pnt_az_mean, pnt_alt_mean = calculate_mean_direction(


### PR DESCRIPTION
Sorry but I realized that the pull request #103 did not solve the problem of creating an event list HDU. The type of `combo_type` is indeed converted to int in `get_stereo_events`, but it is again converted to float in `get_dl2_mean`, where the mean of `combo_type` is calculated and it automatically changes its type. With this pull request I added a line to reconvert it (and in addition `multiplicity`) to int, and it finally fixed the problem. 