### PR TITLE
Skip the event coincidence if no coincident events are found

### DIFF
--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -241,6 +241,10 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
 
             n_coincidences.append(n_coincidence)
 
+        if not any(n_coincidences):
+            logger.info("\nNo coincident events are found. Skipping...")
+            continue
+
         n_coincidences = np.array(n_coincidences)
 
         # Sometimes there are more than one time offset maximizing the


### PR DESCRIPTION
With this pull request I introduced a skip if any coincident events are found in all time offsets. It sometimes happen that an input LST-1 data have only a small number of events, and in that case the script crashed with a bit unclear error message. 