### PR TITLE
Add IRF observation time to the header

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -804,6 +804,7 @@ def load_irf_files(input_dir_irf):
         "QUAL_CUT": [],
         "EVT_TYPE": [],
         "DL2_WEIG": [],
+        "IRF_OBST": [],
         "GH_CUT": [],
         "GH_EFF": [],
         "GH_MIN": [],

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_create_irf.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_create_irf.py
@@ -355,6 +355,9 @@ def create_irf(
     if quality_cuts is not None:
         extra_header["QUAL_CUT"] = quality_cuts
 
+    if is_bkg_mc:
+        extra_header["IRF_OBST"] = (irf_obs_time.to_value("h"), "h")
+
     irf_hdus = fits.HDUList([fits.PrimaryHDU()])
 
     # Apply the gammaness cut


### PR DESCRIPTION
I realized that with the pull request #99 I forgot to add the IRF observation time, which is used for creating a background model, to the extra header, so let me do so with this pull request.