### PR TITLE
Drop the MAGIC events that observation and event IDs are duplicated

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -400,6 +400,10 @@ def load_magic_dl1_data_files(input_dir):
 
     event_data = pd.concat(data_list)
 
+    event_data.drop_duplicates(
+        subset=["obs_id", "event_id", "tel_id"], keep=False, inplace=True
+    )
+
     event_data.rename(
         columns={"obs_id": "obs_id_magic", "event_id": "event_id_magic"}, inplace=True
     )


### PR DESCRIPTION
With this pull request let me drop the MAGIC events whose observation and event IDs are duplicated, which sometimes happen at the DL1 level and might affect the coincidence search.