### PR TITLE
Update the python version and some other packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,11 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - pip
   - astropy
   - black
-  - bokeh=1.0
+  - bokeh
   - nbsphinx
   - ctapipe=0.12
   - gammapy=0.19.0
@@ -36,7 +36,7 @@ dependencies:
   - scikit-learn
   - scipy
   - setuptools
-  - sphinx=4.2
+  - sphinx
   - sphinx-automodapi
   - sphinx_rtd_theme
   - tqdm
@@ -50,7 +50,7 @@ dependencies:
   - eventio>=1.5.0
   - corsikaio
   - pip:
-      - lstchain~=0.9.6
+      - lstchain~=0.9.9
       - ctapipe_io_magic~=0.4.7
-      - ctaplot~=0.5.5
+      - ctaplot~=0.6.2
       - pyirf~=0.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - eventio>=1.5.0
   - corsikaio
   - pip:
-      - lstchain~=0.9.9
+      - lstchain~=0.9.6
       - ctapipe_io_magic~=0.4.7
-      - ctaplot~=0.6.2
+      - ctaplot~=0.5.5
       - pyirf~=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ entry_points["console_scripts"] = [
 tests_require = ["pytest", "pandas>=0.24.0", "importlib_resources;python_version<'3.9'"]
 
 docs_require = [
-    "sphinx~=4.2",
+    "sphinx",
     "sphinx-automodapi",
     "sphinx_argparse",
     "sphinx_rtd_theme",
@@ -34,10 +34,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         'astropy>=4.0.5,<5',
-        'lstchain~=0.9.6',
+        'lstchain~=0.9.9',
         'ctapipe~=0.12.0',
         'ctapipe_io_magic~=0.4.7',
-        'ctaplot~=0.5.5',
+        'ctaplot~=0.6.2',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.19.0',
         'uproot~=4.1',

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         'astropy>=4.0.5,<5',
-        'lstchain~=0.9.9',
+        'lstchain~=0.9.6',
         'ctapipe~=0.12.0',
         'ctapipe_io_magic~=0.4.7',
-        'ctaplot~=0.6.2',
+        'ctaplot~=0.5.5',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.19.0',
         'uproot~=4.1',


### PR DESCRIPTION
With this pull request I updated the python version to 3.8 to use a new feature, and accordingly other packages. Removing the requirement on `bokeh` is needed to update the python version, and regarding `sphinx` I just let it follow the requirement of the other packages. For the other packages I just updated the versions. @aleberti could you please have a look? Thanks in advance.