### PR TITLE
Change the default settings of `max_features`

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -87,7 +87,7 @@ energy_regressor:
         min_samples_split: 2
         min_samples_leaf: 2
         min_weight_fraction_leaf: 0.0
-        max_features: "auto"
+        max_features: 1.0
         max_leaf_nodes: null
         min_impurity_decrease: 0.0
         bootstrap: true
@@ -124,7 +124,7 @@ disp_regressor:
         min_samples_split: 2
         min_samples_leaf: 2
         min_weight_fraction_leaf: 0.0
-        max_features: "auto"
+        max_features: 1.0
         max_leaf_nodes: null
         min_impurity_decrease: 0.0
         bootstrap: true
@@ -161,7 +161,7 @@ event_classifier:
         min_samples_split: 2
         min_samples_leaf: 2
         min_weight_fraction_leaf: 0.0
-        max_features: "auto"
+        max_features: "sqrt"
         max_leaf_nodes: null
         min_impurity_decrease: 0.0
         bootstrap: true


### PR DESCRIPTION
After updating the magic-cta-pipe environment a new version of scikit-learn (v1.1.2) is installed, which is OK because we do not specify any requirements to that module. However there is a future warning appeared during training RFs that the `max_features = "auto"` is deprecated. For RF regressors the "auto" means that all the features are considered at each split, and for RF classifiers  the `sqrt(n_features)` is used. It suggested to use them explicitly, so I changed the default settings as follows. Now the `max_features = 1.0` is used for RF regressors, which in case of float the `n_features * max_features` is used, so the setting is actually not changed. 