### PR TITLE
allow to further merge already merged files

### DIFF
--- a/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
+++ b/magicctapipe/scripts/lst1_magic/merge_hdf_files.py
@@ -142,6 +142,7 @@ def merge_hdf_files(input_dir, output_dir=None, run_wise=False, subrun_wise=Fals
     # Parse information from the input file names
     regex_run = re.compile(r"(\S+run)(\d+)\.h5", re.IGNORECASE)
     regex_subrun = re.compile(r"(\S+run)(\d+)\.(\d+)\.h5", re.IGNORECASE)
+    regex_run_merged = re.compile(r"(\S+run)(\d+)_to_(\d+)\.h5", re.IGNORECASE)
 
     file_names = []
     run_ids = []
@@ -161,6 +162,12 @@ def merge_hdf_files(input_dir, output_dir=None, run_wise=False, subrun_wise=Fals
             file_names.append(parser[0])
             run_ids.append(parser[1])
             subrun_ids.append(parser[2])
+
+        elif re.fullmatch(regex_run_merged, input_file_name):
+            parser = re.findall(regex_run_merged, input_file_name)[0]
+            file_names.append(parser[0])
+            run_ids.append(parser[1])
+            run_ids.append(parser[2])
 
     file_names_unique = np.unique(file_names)
 


### PR DESCRIPTION
modified slightly the script for merging the files to allow to merge again files that were already merged. I.e. to merge run1_to_100, run_101_to_200, run_201_to_300 into run1_to_300. I checked (on MC dl1 files) that it does not break the regular  behavior) and on merged dl2 files that it works. 
One small issue is that if you merge e.g. 1_to_1000 and 2000_to_3000 it will stay say 1_to_3000 even if it does not have all the runs in between, which might be in some occasions misleading, however this was already happening before and it is also possible to have a run missing 