### PR TITLE
Load dl2 data exc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           . $CONDA/etc/profile.d/conda.sh
           conda config --set always_yes yes --set changeps1 no
           sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-          conda env create -n ci -f environment.yml
+          conda install mamba -n base -c conda-forge
+          mamba env create -n ci -f environment.yml
           conda activate ci
           # we install ctapipe using pip to be able to select any commit, e.g. the current master
           pip install pytest-cov "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION"

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -681,6 +681,11 @@ def load_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
         ON time of the input data
     deadc: float
         Dead time correction factor
+
+    Raises
+    ------
+    ValueError
+        If the input event type is not known
     """
 
     # Load the input file
@@ -707,6 +712,9 @@ def load_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
             "WARNING: Please confirm that this type is correct for the input data, "
             "since the hardware trigger between LST-1 and MAGIC may NOT be used."
         )
+
+    else:
+        raise ValueError(f"Unknown event type '{event_type}'.")
 
     n_events = len(event_data.groupby(["obs_id", "event_id"]).size())
     logger.info(f"--> {n_events} stereo events")


### PR DESCRIPTION
Exception handling (event type) in `load_dl2-data_file`. Mamba instead of conda in CI (with conda, workflows fail and dependencies can't be installed)