### PR TITLE
Update coincident event search using large shower events

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -69,11 +69,12 @@ MAGIC:
 event_coincidence:
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"
-    search_method: "all_combination" # select "all_combination" or "scan"
+    pre_offset_search: true
+    n_pre_offset_search_events: 100
     time_offset:
         start: "-10 us"
         stop: "0 us"
-    n_search_coincident_events: 100
+
 
 stereo_reco:
     quality_cuts: "(intensity > 50) & (width > 0)"

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -73,7 +73,7 @@ event_coincidence:
     time_offset:
         start: "-10 us"
         stop: "0 us"
-    n_large_shower_events: 50	      	     
+    n_search_coincident_events: 50
 
 stereo_reco:
     quality_cuts: "(intensity > 50) & (width > 0)"

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -73,7 +73,7 @@ event_coincidence:
     time_offset:
         start: "-10 us"
         stop: "0 us"
-    n_search_coincident_events: 50
+    n_search_coincident_events: 100
 
 stereo_reco:
     quality_cuts: "(intensity > 50) & (width > 0)"

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -69,10 +69,11 @@ MAGIC:
 event_coincidence:
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"
+    search_method: "all_combination" # select "all_combination" or "scan"
     time_offset:
         start: "-10 us"
         stop: "0 us"
-
+    n_large_shower_events: 50	      	     
 
 stereo_reco:
     quality_cuts: "(intensity > 50) & (width > 0)"

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -60,7 +60,6 @@ import yaml
 from astropy import units as u
 from ctapipe.instrument import SubarrayDescription
 from magicctapipe.io import (
-    format_object,
     get_stereo_events,
     load_lst_dl1_data_file,
     load_magic_dl1_data_files,
@@ -142,10 +141,10 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
         pre_offset_search = config_coinc["pre_offset_search"]
 
     if pre_offset_search:
-        logger.info(f"\nPre offset search will be performed.")
+        logger.info("\nPre offset search will be performed.")
         n_pre_offset_search_events = config_coinc["n_pre_offset_search_events"]
     else:
-        logger.info(f"\noffset scan range defined in the config file will be used.")
+        logger.info("\noffset scan range defined in the config file will be used.")
         offset_start = u.Quantity(config_coinc["time_offset"]["start"])
         offset_stop = u.Quantity(config_coinc["time_offset"]["stop"])
 

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -220,14 +220,12 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
             # numbers of MAGIC events are left for the pre offset search.
             # To find large-intensity showers within the same time window,
             # time cut around MAGIC observations is applied to the LST data set.
-            cond_lolim = (
-                timestamps_lst
-                >= timestamps_magic[mask_lst_obs_window][0] - window_half_width
-            )
-            cond_uplim = (
-                timestamps_lst
-                <= timestamps_magic[mask_lst_obs_window][-1] + window_half_width
-            )
+            time_lolim = timestamps_magic[mask_lst_obs_window][0] - window_half_width
+            time_uplim = timestamps_magic[mask_lst_obs_window][-1] + window_half_width
+
+            cond_lolim = timestamps_lst >= time_lolim
+            cond_uplim = timestamps_lst <= time_uplim
+
             mask_magic_obs_window = np.logical_and(cond_lolim, cond_uplim)
 
             if np.count_nonzero(mask_magic_obs_window) == 0:

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -34,7 +34,7 @@ as summarized below:
 * March 10 2023 to March 30 2023: -76039.3 us
 * after April 13 2023: -25.1 us
 By default, pre offset search is performed using large shower events.
-The possible time offset is found among all possible combination of 
+The possible time offset is found among all possible combinations of 
 time offsets using those events. Finally, the time offset scan is performed
 around the possible offset found by the pre offset search. Instead of that,
 you can also define the offset scan range in the configuration file.
@@ -184,9 +184,9 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
         df_magic.drop(["time_sec", "time_nanosec"], axis=1, inplace=True)
 
         # Pre offset search is performed to define the offset scan region.
-        # First, N events are extracted from largerst intensity events for LST and
-        # MAGIC. Then, it counts a number of coincident events within a defined
-        # window after shifting all possible combination (N x N) of time offsets.
+        # First, N events are extracted from largest intensity events for LST and
+        # MAGIC. Then, it counts the number of coincident events within a defined
+        # window after shifting all possible combinations (N x N) of time offsets.
         if pre_offset_search:
             logger.info(
                 "\nPre offset search using large-intensity shower events is ongoing..."

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -202,9 +202,6 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
 
             logger.info(f"--> {n_events_magic} events are found.")
 
-            # df_magic = df_magic.iloc[mask]
-            # timestamps_magic = timestamps_magic[mask]
-
             index_large_intensity_magic = np.argsort(df_magic["intensity"][mask])[::-1][
                 :n_search_coincident_events
             ]

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -280,9 +280,11 @@ def event_coincidence(input_file_lst, input_dir_magic, output_dir, config):
                 f"\nPre offset search finds {offset_at_max_pre_search} as a possible offset"
             )
 
-            # offset scan region is defined as between +/- full window width around the offset_at_max
-            offset_start = offset_at_max_pre_search - 2 * window_half_width
-            offset_stop = offset_at_max_pre_search + 2 * window_half_width
+            # offset scan region is defined as 3 x half window width
+            # around the offset_at_max to cover "full window width" which will
+            # be used to compute weighted average of the time offset
+            offset_start = offset_at_max_pre_search - 3 * window_half_width
+            offset_stop = offset_at_max_pre_search + 3 * window_half_width
 
         logger.info("\nTime offsets scan region:")
         logger.info(f"  start: {offset_start.to('us').round(1)}")


### PR DESCRIPTION
Since the time offset depends on the observation dates, we needed to tune the offset scan region if we use the current method. This PR adds an option (`all_combination`) to select the best time offset among all possible combinations using large shower events. For the moment, 50 (MAGIC) x 50 (LST) events are selected by default to compute all possible time offsets and count coincident events with an assumed offset.