### PR TITLE
Zenith interpol

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -840,6 +840,7 @@ def load_irf_files(input_dir_irf):
         "migration_bins": [],
         "source_offset_bins": [],
         "bkg_fov_offset_bins": [],
+        "file_names": [],
     }
 
     # Find the input files
@@ -861,7 +862,7 @@ def load_irf_files(input_dir_irf):
     for input_file in input_files_irf:
         logger.info(input_file)
         irf_hdus = fits.open(input_file)
-
+        irf_data["file_names"].append(input_file)
         # Read the header
         header = irf_hdus["EFFECTIVE AREA"].header
 
@@ -979,6 +980,7 @@ def load_irf_files(input_dir_irf):
     irf_data["grid_points"] = np.array(irf_data["grid_points"])
     irf_data["energy_dispersion"] = np.array(irf_data["energy_dispersion"])
     irf_data["migration_bins"] = np.array(irf_data["migration_bins"])
+    irf_data["file_names"] = np.array(irf_data["file_names"])
 
     if "gh_cuts" in irf_data:
         irf_data["gh_cuts"] = np.array(irf_data["gh_cuts"])

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -248,7 +248,7 @@ create_irf:
 dl2_to_dl3:
     interpolation_method: "linear"  # select "nearest", "linear" or "cubic"
     interpolation_scheme: "cosZd" # select "cosZdAz" or "cosZd"
-    max_distance: 45 # in degrees or null
+    max_distance: "45. deg"  # angle type Quantity, or comment out to remove the cut
     source_name: "Crab"
     source_ra: null  # used when the source name cannot be resolved
     source_dec: null  # used when the source name cannot be resolved

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -246,7 +246,9 @@ create_irf:
 
 
 dl2_to_dl3:
-    interpolation_method: "nearest"  # select "nearest", "linear" or "cubic"
+    interpolation_method: "linear"  # select "nearest", "linear" or "cubic"
+    interpolation_scheme: "cosZd" # select "cosZdAz" or "cosZd"
+    max_distance: 45 # in degrees or null
     source_name: "Crab"
     source_ra: null  # used when the source name cannot be resolved
     source_dec: null  # used when the source name cannot be resolved

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl2_to_dl3.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl2_to_dl3.py
@@ -154,7 +154,6 @@ def dl2_to_dl3(input_file_dl2, input_dir_irf, output_dir, config):
 
     # Prepare for the IRF interpolations
     interpolation_method = config_dl3.pop("interpolation_method")
-
     logger.info(f"\nInterpolation method: {interpolation_method}")
 
     extra_header["IRF_INTP"] = interpolation_method


### PR DESCRIPTION
 changes for source path interpolation:

- added a possibility to use node up to a given distance from the data (this is useful to select only the nodes on the raising or falling part of the source path)
- allowed two interpolation schemes cosZdAz - like it was before, and cosZd (in which the interpolation is done only over cosZd, but normally you would select with the option above the nodes with similar azimuth)