### PR TITLE
changed the gap size from 0.1s to 1 s

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -60,7 +60,7 @@ EFFECTIVE_FOCLEN_LST = 29.30565 * u.m
 
 # The upper limit of the trigger time differences of consecutive events,
 # used when calculating the ON time and dead time correction factor
-TIME_DIFF_UPLIM = 0.1 * u.s
+TIME_DIFF_UPLIM = 1.0 * u.s
 
 # The LST-1 and MAGIC readout dead times
 DEAD_TIME_LST = 7.6 * u.us


### PR DESCRIPTION
this is used in the computation of the dead time, but the output is also stored in DL3 index file since load_dl2_data is normally run with a quality cut in disp_diff its rate of events is much smaller, and cutting everything >0.1 s removes a lot of real ontime (~40%). This does not have affect the spectra (probably), because gammapy is recomputing the ontime, but still produces a very confusing information inside the DL3 index files 1s should be small enough to remove real gaps.