### PR TITLE
Update the history of the time offset between LST-1 and MAGIC

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -67,6 +67,12 @@ MAGIC:
 
 
 event_coincidence:
+    # History of the time offset between LST-1 and MAGIC
+    # before June 12 2021: -3.1 us
+    # June 13 2021 to Feb 28 2023: -6.5 us
+    # March 10 2023 to March 30 2023: -76039.3 us
+    # April 13 2023 to August 2023: -25.1 us
+    # after Sep 11 2023 : -6.2 us
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"
     pre_offset_search: true

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -32,7 +32,8 @@ as summarized below:
 * before June 12 2021: -3.1 us
 * June 13 2021 to Feb 28 2023: -6.5 us
 * March 10 2023 to March 30 2023: -76039.3 us
-* after April 13 2023: -25.1 us
+* April 13 2023 to August 2023: -25.1 us
+* after Sep 11 2023 : -6.2 us
 By default, pre offset search is performed using large shower events.
 The possible time offset is found among all possible combinations of 
 time offsets using those events. Finally, the time offset scan is performed


### PR DESCRIPTION
After WRS re-synchronization, the time offset between LST-1 and MAGIC was changed to -6.2 us.
This PR just updated the history comment in the script and config file.