### PR TITLE
Update CI badge according to latest practices.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Instructions for developers
 Developers should follow the development install instructions found in the
 `documentation <https://magic-cta-pipe.readthedocs.io/en/latest/developer-guide/getting-started.html>`_.
 
-.. |Actions Status| image:: https://github.com/cta-observatory/magic-cta-pipe/workflows/CI/badge.svg
+.. |Actions Status| image:: https://github.com/cta-observatory/magic-cta-pipe/actions/workflows/ci.yml/badge.svg?branch=master
     :target: https://github.com/cta-observatory/magic-cta-pipe/actions
     :alt: magic-cta-pipe GitHub Actions CI Status
 


### PR DESCRIPTION
Following https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge. The badge was showing "failing" even if the CI was succesfull.