### PR TITLE
Correct name of branch for pre-commit workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.8
       - uses: pre-commit/action@v3.0.0
         with:
-          extra_args: --files $(git diff origin/main --name-only)
+          extra_args: --files $(git diff origin/master --name-only)
 
   pyflakes:
     if: contains(github.event.pull_request.labels.*.name, 'documentation-only') == false


### PR DESCRIPTION
I realized that despite the name of the branch was wrong in the `pre-commit` command, it was passing anyway. Now corrected the name to `master`.