### PR TITLE
Update time offset history

### DIFF
--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -74,7 +74,8 @@ event_coincidence:
     # April 13 2023 to August 2023: -25.1 us
     # Sep 11 2023 to Nov 14 2023: -6.2 us
     # Nov 15 2023: -1583.8 us
-    # After Nov 16 2023 : 118.8 us
+    # Nov 16 2023 to Nov 30 2023: 118.8 us
+    # After Dec 1 2023: -3.2 us
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"
     pre_offset_search: true

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -72,7 +72,9 @@ event_coincidence:
     # June 13 2021 to Feb 28 2023: -6.5 us
     # March 10 2023 to March 30 2023: -76039.3 us
     # April 13 2023 to August 2023: -25.1 us
-    # after Sep 11 2023 : -6.2 us
+    # Sep 11 2023 to Nov 14: -6.2 us
+    # Nov 15: -1583.8 us
+    # After Nov 16 2023 : 118.8 us
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"
     pre_offset_search: true

--- a/magicctapipe/scripts/lst1_magic/config.yaml
+++ b/magicctapipe/scripts/lst1_magic/config.yaml
@@ -72,8 +72,8 @@ event_coincidence:
     # June 13 2021 to Feb 28 2023: -6.5 us
     # March 10 2023 to March 30 2023: -76039.3 us
     # April 13 2023 to August 2023: -25.1 us
-    # Sep 11 2023 to Nov 14: -6.2 us
-    # Nov 15: -1583.8 us
+    # Sep 11 2023 to Nov 14 2023: -6.2 us
+    # Nov 15 2023: -1583.8 us
     # After Nov 16 2023 : 118.8 us
     timestamp_type_lst: "dragon_time"  # select "dragon_time", "tib_time" or "ucts_time"
     window_half_width: "300 ns"

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -33,8 +33,8 @@ as summarized below:
 * June 13 2021 to Feb 28 2023: -6.5 us
 * March 10 2023 to March 30 2023: -76039.3 us
 * April 13 2023 to August 2023: -25.1 us
-* Sep 11 2023 to Nov 14: -6.2 us
-* Nov 15: -1583.8 us
+* Sep 11 2023 to Nov 14 2023: -6.2 us
+* Nov 15 2023: -1583.8 us
 * After Nov 16 2023 : 118.8 us
 By default, pre offset search is performed using large shower events.
 The possible time offset is found among all possible combinations of

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -35,7 +35,8 @@ as summarized below:
 * April 13 2023 to August 2023: -25.1 us
 * Sep 11 2023 to Nov 14 2023: -6.2 us
 * Nov 15 2023: -1583.8 us
-* After Nov 16 2023 : 118.8 us
+* Nov 16 2023 to Nov 30 2023: 118.8 us
+* After Dec 1 2023: -3.2 us
 By default, pre offset search is performed using large shower events.
 The possible time offset is found among all possible combinations of
 time offsets using those events. Finally, the time offset scan is performed

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -33,7 +33,9 @@ as summarized below:
 * June 13 2021 to Feb 28 2023: -6.5 us
 * March 10 2023 to March 30 2023: -76039.3 us
 * April 13 2023 to August 2023: -25.1 us
-* after Sep 11 2023 : -6.2 us
+* Sep 11 2023 to Nov 14: -6.2 us
+* Nov 15: -1583.8 us
+* After Nov 16 2023 : 118.8 us
 By default, pre offset search is performed using large shower events.
 The possible time offset is found among all possible combinations of
 time offsets using those events. Finally, the time offset scan is performed


### PR DESCRIPTION
After the power cut and WRS synchronization, the time offset between MAGIC and LST1 was changed: -1583.8 us on Nov 15, 118.8 us since Nov 16.