### PR TITLE
fix to create HDU and OBS index files with lstchain0.10

### DIFF
--- a/magicctapipe/scripts/lst1_magic/create_dl3_index_files.py
+++ b/magicctapipe/scripts/lst1_magic/create_dl3_index_files.py
@@ -17,6 +17,7 @@ import time
 from pathlib import Path
 
 from lstchain.high_level import create_hdu_index_hdu, create_obs_index_hdu
+
 __all__ = ["create_dl3_index_files"]
 
 logger = logging.getLogger(__name__)

--- a/magicctapipe/scripts/lst1_magic/create_dl3_index_files.py
+++ b/magicctapipe/scripts/lst1_magic/create_dl3_index_files.py
@@ -17,7 +17,6 @@ import time
 from pathlib import Path
 
 from lstchain.high_level import create_hdu_index_hdu, create_obs_index_hdu
-
 __all__ = ["create_dl3_index_files"]
 
 logger = logging.getLogger(__name__)
@@ -59,9 +58,7 @@ def create_dl3_index_files(input_dir):
 
     for input_file in input_files:
         logger.info(input_file)
-
-        input_file_name = Path(input_file).name
-        file_names.append(input_file_name)
+        file_names.append(Path(input_file))
 
     # Create the DL3 index files
     logger.info("\nCreating DL3 index files...")
@@ -70,15 +67,13 @@ def create_dl3_index_files(input_dir):
     obs_index_file = f"{input_dir}/obs-index.fits.gz"
 
     create_hdu_index_hdu(
-        filename_list=file_names,
-        fits_dir=Path(input_dir),
+        file_list=file_names,
         hdu_index_file=Path(hdu_index_file),
         overwrite=True,
     )
 
     create_obs_index_hdu(
-        filename_list=file_names,
-        fits_dir=Path(input_dir),
+        file_list=file_names,
         obs_index_file=Path(obs_index_file),
         overwrite=True,
     )


### PR DESCRIPTION
after removing the old copied lstchain code for creating those index files and using the current (lstchain 0.10) code instead the script stoped working because of a small change of API in the function. Note that since the function is taken from lstchain, in the header file of the output index files 'lstchain' will be written as the creation program

@aleberti or  @Elisa-Visentin, please have a quick look and if you are fine with those changes we merge them into the "lstchain" branch  