### PR TITLE
Update python version for readthedocs (now failing).

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: "2"
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:


### PR DESCRIPTION
This should fix the building of the documentation in the readthedocs server, since the python version now required by lstchain and ctapipe is at least 3.9.