### PR TITLE
Add in README a note about different LST-1 data and MCP versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ According to this, if you need to analyze joint data where the version of LST-1 
 
 Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition,
 the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the
-data at high level. Once all the LST-1 DL1 data will be reprocessed, *magic-cta-pipe* v0.3.1 will be the only version to use
+data at high level. Once all the LST-1 DL1 data will be reprocessed, *magic-cta-pipe* v0.4.1 will be the only version to use
 for the joint analysis.
 
 Installation for users

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ According to this, if you need to analyze joint data where the version of LST-1 
 * if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
 * if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
 
-Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition
+Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition,
 the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the
 data at high level. Once all the LST-1 DL1 data will be reprocessed, *magic-cta-pipe* v0.3.1 will be the only version to use
 for the joint analysis.

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ v0.4.1 contains backward incompatible changes with respect to v0.3.1. Therefore,
 At the moment of the release v0.4.1 of *magic-cta-pipe*, some LST-1 data are processed with *cta-lstchain* v0.9.x,
 while the most recent ones are processed with v0.10.x.
 According to this, if you need to analyze joint data where the version of LST-1 data is different, then:
-* if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
-* if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
+- if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
+- if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
 
 Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition
 the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,9 @@ v0.4.1 contains backward incompatible changes with respect to v0.3.1. Therefore,
 At the moment of the release v0.4.1 of *magic-cta-pipe*, some LST-1 data are processed with *cta-lstchain* v0.9.x,
 while the most recent ones are processed with v0.10.x.
 According to this, if you need to analyze joint data where the version of LST-1 data is different, then:
-- if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
-- if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
+
+* if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
+* if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
 
 Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition
 the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,19 @@ v0.3.1 of *magic-cta-pipe* was the last release before the cleanup of old files.
 In order to exploit fully the new functionalities provided by *ctapipe*, use always the latest stable release of *magic-cta-pipe* (currently v0.4.1).
 v0.4.1 contains backward incompatible changes with respect to v0.3.1. Therefore, you cannot mix analyses performed with the two releases.
 
+**COMPATIBILITY OF MAGIC-CTA-PIPE WITH LSTCHAIN DATA**
+
+At the moment of the release v0.4.1 of *magic-cta-pipe*, some LST-1 data are processed with *cta-lstchain* v0.9.x,
+while the most recent ones are processed with v0.10.x.
+According to this, if you need to analyze joint data where the version of LST-1 data is different, then:
+* if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
+* if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
+
+Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition
+the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the
+data at high level. Once all the LST-1 DL1 data will be reprocessed, *magic-cta-pipe* v0.3.1 will be the only version to use
+for the joint analysis.
+
 Installation for users
 ----------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,20 @@ Check out the :doc:`user-guide/index` section for the analysis steps, including 
 
    This project is under active development.
 
+.. note::
+
+   At the moment of the release v0.4.1 of *magic-cta-pipe*, some LST-1 data are processed with *cta-lstchain* v0.9.x,
+   while the most recent ones are processed with v0.10.x.
+   According to this, if you need to analyze joint data where the version of LST-1 data is different, then:
+
+   * if LST-1 data were processed with *cta-lstchain* v0.9.x, you need to use *magic-cta-pipe* v0.3.1
+   * if LST-1 data were processed with *cta-lstchain* v0.10.x, you need to use *magic-cta-pipe* v0.4.1
+
+   Note that there are quite a lot of differences between v0.3.1 and v0.4.1, like for the telescope combinations definition,
+   the way IRF are created (due to different *pyirf* versions) and so on. Therefore it may not be straightforward to stack the
+   data at high level. Once all the LST-1 DL1 data will be reprocessed, *magic-cta-pipe* v0.4.1 will be the only version to use
+   for the joint analysis.
+
 Contents
 --------
 


### PR DESCRIPTION
Add a note that depending on the LST-1 data to analyze, different versions of MCP need to be used due to the incompatible versions of the subarray, camera and optics tables saved in the Subarray object by ctapipe v0.12 and v0.19.