### PR TITLE
Fix tests docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
 
       - name: Tests
         env:
-          MAGIC_CTA_DATA_USER: ${{ secrets.magic_cta_data_user }}
-          MAGIC_CTA_DATA_PASSWORD: ${{ secrets.magic_cta_data_password }}
+          MAGIC_CTA_DATA_USER: '${{ secrets.magic_cta_data_user }}'
+          MAGIC_CTA_DATA_PASSWORD: '${{ secrets.magic_cta_data_password }}'
         run: |
           coverage run -m pytest -vra
           coverage xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,7 +230,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "cython": ("https://docs.cython.org/en/latest/", None),
-    "iminuit": ("https://iminuit.readthedocs.io/en/latest/", None),
+    "iminuit": ("https://scikit-hep.org/iminuit/", None),
     "traitlets": ("https://traitlets.readthedocs.io/en/stable/", None),
     "ctapipe": ("https://ctapipe.readthedocs.io/en/v0.19.2/", None),
     "pyirf": ("https://pyirf.readthedocs.io/en/stable/", None),


### PR DESCRIPTION
Fixes the running of tests by adding single quotes when getting secrets, which avoids that special characters are wrongly interpreted. Also fixes documentation with the new URL for the iminuit documentation, now moved to https://scikit-hep.org/iminuit/.