### PR TITLE
Add codecov token to upload reports.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,7 @@ jobs:
           coverage xml
 
       - uses: codecov/codecov-action@v4
+        if: contains(github.event.pull_request.labels.*.name, 'documentation-only') == false
+        with:
+            fail_ci_if_error: true
+            token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes the issue with codecov reports not uploaded as reported in latest actions. 