### PR TITLE
Separating generation of the SLURM-specific lines 

### DIFF
--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/__init__.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/__init__.py
@@ -1,3 +1,4 @@
+from .clusters import slurm_lines
 from .coincident_events import configfile_coincidence, linking_bash_lst
 from .merging_runs import cleaning, merge, mergeMC, split_train_test
 from .setting_up_config_and_dir import (
@@ -22,4 +23,5 @@ __all__ = [
     "configfile_stereo",
     "bash_stereo",
     "bash_stereoMC",
+    "slurm_lines",
 ]

--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/clusters.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/clusters.py
@@ -30,6 +30,7 @@ def slurm_lines(p, J, array=None, mem=None, out_err=None):
         f"#SBATCH -p {p}\n",
         f"#SBATCH -J {J}\n",
         f"#SBATCH --array=0-{array}\n" if array is not None else "",
+        f"#SBATCH --mem {mem}\n" if mem is not None else "",
         "#SBATCH -n 1\n\n",
         f"#SBATCH --output={out_err}.out\n" if out_err is not None else "",
         f"#SBATCH --error={out_err}.err\n\n" if out_err is not None else "",

--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/clusters.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/clusters.py
@@ -1,0 +1,40 @@
+"""
+Module for generating bash script lines for running analysis in different clusters
+"""
+
+
+def slurm_lines(p, J, array=None, mem=None, out_err=None):
+    """
+    Function for creating the general lines that slurm scripts are starting with.
+
+    Parameters
+    ----------
+    p : str
+        Name of the queue
+    J : str
+        Job name
+    array : None or int
+        If not none array of jobs from 0 to array will be made
+    mem : None or str
+        Requested memory
+    out_err : None or str
+        If the output should be written to a specific output file
+
+    Returns
+    -------
+    list
+        List of strings
+    """
+    lines = [
+        "#!/bin/sh\n\n",
+        f"#SBATCH -p {p}\n",
+        f"#SBATCH -J {J}\n",
+        f"#SBATCH --array=0-{array}\n" if array is not None else "",
+        "#SBATCH -n 1\n\n",
+        f"#SBATCH --output={out_err}.out\n" if out_err is not None else "",
+        f"#SBATCH --error={out_err}.err\n\n" if out_err is not None else "",
+        "ulimit -l unlimited\n",
+        "ulimit -s unlimited\n",
+        "ulimit -a\n\n",
+    ]
+    return lines

--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/coincident_events.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/coincident_events.py
@@ -25,6 +25,7 @@ import numpy as np
 import yaml
 
 from magicctapipe import __version__
+from magicctapipe.scripts.lst1_magic.semi_automatic_scripts.clusters import slurm_lines
 
 __all__ = ["configfile_coincidence", "linking_bash_lst"]
 
@@ -165,18 +166,14 @@ def linking_bash_lst(
 
                     if process_size < 0:
                         continue
-                    lines = [
-                        "#!/bin/sh\n\n",
-                        "#SBATCH -p short\n",
-                        f"#SBATCH -J {source_name}_coincidence\n",
-                        f"#SBATCH --array=0-{process_size}\n",
-                        "#SBATCH --mem=8g\n",
-                        "#SBATCH -n 1\n\n",
-                        f"#SBATCH --output={outputdir}/logs/slurm-%x.%A_%a.out"
-                        f"#SBATCH --error={outputdir}/logs/slurm-%x.%A_%a.err"
-                        "ulimit -l unlimited\n",
-                        "ulimit -s unlimited\n",
-                        "ulimit -a\n\n",
+                    slurm = slurm_lines(
+                        p="short",
+                        J=f"{source_name}_coincidence",
+                        array=process_size,
+                        mem="8g",
+                        out_err=f"{outputdir}/logs/slurm-%x.%A_%a",
+                    )
+                    lines = slurm + [
                         f"export INM={MAGIC_DL1_dir}/Merged/Merged_{str(Y_M).zfill(4)}_{str(M_M).zfill(2)}_{str(D_M).zfill(2)}\n",
                         f"export OUTPUTDIR={outputdir}\n",
                         "SAMPLE_LIST=($(<$OUTPUTDIR/logs/list_LST.txt))\n",
@@ -226,18 +223,14 @@ def linking_bash_lst(
                 process_size = len(f.readlines()) - 1
 
             with open(f"LST_coincident_{nightLST.split('/')[-1]}.sh", "w") as f:
-                lines = [
-                    "#!/bin/sh\n\n",
-                    "#SBATCH -p short\n",
-                    f"#SBATCH -J {process_name}_coincidence\n",
-                    f"#SBATCH --array=0-{process_size}%50\n",
-                    "#SBATCH --mem=8g\n",
-                    "#SBATCH -n 1\n\n",
-                    f"#SBATCH --output={nightLST}/slurm-%x.%A_%a.out"
-                    f"#SBATCH --error={nightLST}/slurm-%x.%A_%a.err"
-                    "ulimit -l unlimited\n",
-                    "ulimit -s unlimited\n",
-                    "ulimit -a\n\n",
+                slurm = slurm_lines(
+                    p="short",
+                    J=f"{process_name}_coincidence",
+                    array=process_size,
+                    mem="8g",
+                    out_err=f"{nightLST}/slurm-%x.%A_%a",
+                )
+                lines = slurm + [
                     f"export INM={nightMAGIC}\n",
                     f"export OUTPUTDIR={nightLST}\n",
                     "SAMPLE_LIST=($(<$OUTPUTDIR/list_LST.txt))\n",

--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/setting_up_config_and_dir.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/setting_up_config_and_dir.py
@@ -676,6 +676,7 @@ def main():
                         launch_jobs_MC = f"linking{n}=$(sbatch --parsable {run}) && running{n}=$(sbatch --parsable --dependency=afterany:$linking{n} {run[0:-3]}_r.sh)"
                     else:
                         launch_jobs_MC = f"{launch_jobs_MC} && linking{n}=$(sbatch --parsable {run}) && running{n}=$(sbatch --parsable --dependency=afterany:$linking{n} {run[0:-3]}_r.sh)"
+
                 os.system(launch_jobs_MC)
 
         # Below we run the analysis on the MAGIC data


### PR DESCRIPTION
the generation of the script lines for SLURM was used in ~10 different places, and also sometimes it was not done properly, because the lines were merging, e.g.:

```
!/bin/sh

#SBATCH -p short
#SBATCH -J Crabtest
#SBATCH --array=0-12
#SBATCH -n 1

#SBATCH --output=/home/julian.sitarek/ws/analiza/autoMCP/20240508/out/v0.4.2.dev60+gc16368d.d20240405/Crabtest/DL1/M2/2023_11_19/5111122/logs/slurm-%x.%A_%a.out#SBATCH --error=/home/julian.sitarek/ws/ana
liza/autoMCP/20240508/out/v0.4.2.dev60+gc16368d.d20240405/Crabtest/DL1/M2/2023_11_19/5111122/logs/slurm-%x.%A_%a.err#SBATCH --mem 2g

ulimit -l unlimited
ulimit -s unlimited
ulimit -a
```
Now it is moved to a separate function where you can set most important parameters 