### PR TITLE
Auto mcp errors

### DIFF
--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/setting_up_config_and_dir.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/setting_up_config_and_dir.py
@@ -660,7 +660,7 @@ def main():
                     else:
                         launch_jobs_MC = f"{launch_jobs_MC} && linking{n}=$(sbatch --parsable {run}) && running{n}=$(sbatch --parsable --dependency=afterany:$linking{n} {run[0:-3]}_r.sh)"
 
-                # os.system(launch_jobs_MC)
+                os.system(launch_jobs_MC)
 
         # Below we run the analysis on the MAGIC data
         if (


### PR DESCRIPTION
added simple tracking of errors: the return code of each job is stored into .../logs/list_return.log together with the name of the processed file, slurm job id, and task id, e.g.:
```
/fefs/onsite/common/MAGIC/data/M1/event/Calibrated/2023/11/22/20231122_M1_05111165.002_Y_CrabNebula-W0.40+035.root 35095565 1 137
```
137 at the end is because I deliberately run the job with too small memory so it crashed
