### PR TITLE
fix for #224

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -375,10 +375,10 @@ def get_stereo_events(
     # exclude events in which more than one (LST-1) image gets matched to the same event
     multimatch = event_data_stereo.groupby(group_index + ["tel_id"]).size() > 1
     if sum(multimatch) > 0:
-        print(f"{sum(multimatch)} events with multiple matches")
-        print(event_data_stereo[multimatch])
+        logger.info(f"{sum(multimatch)} events with multiple matches")
+        logger.info(event_data_stereo[multimatch])
         if sum(multimatch) > 5:
-            print("this is too much, exiting")
+            logger.error("this is too much, exiting")
             exit(11)
         event_data_stereo = event_data_stereo[~multimatch]
 

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -372,10 +372,6 @@ def get_stereo_events(
     if quality_cuts is not None:
         event_data_stereo.query(quality_cuts, inplace=True)
 
-    # Extract stereo events
-    event_data_stereo["multiplicity"] = event_data_stereo.groupby(group_index).size()
-    event_data_stereo.query("multiplicity > 1", inplace=True)
-
     # exclude events in which more than one (LST-1) image gets matched to the same event
     multimatch = event_data_stereo.groupby(group_index + ["tel_id"]).size() > 1
     if sum(multimatch) > 0:
@@ -385,10 +381,10 @@ def get_stereo_events(
             print("this is too much, exiting")
             exit(11)
         event_data_stereo = event_data_stereo[~multimatch]
-        # if we exclude 2 LST-1 images we would still have the MAGIC images left for which we need to recompute multiplicity
-        event_data_stereo.loc[
-            event_data_stereo.index, "multiplicity"
-        ] = event_data_stereo.groupby(group_index).size()
+
+    # Extract stereo events
+    event_data_stereo["multiplicity"] = event_data_stereo.groupby(group_index).size()
+    event_data_stereo.query("multiplicity > 1", inplace=True)
 
     if eval_multi_combo:
         # Check the total number of events

--- a/magicctapipe/io/tests/test_io.py
+++ b/magicctapipe/io/tests/test_io.py
@@ -639,6 +639,21 @@ def test_exist_coincidence_stereo(coincidence_stereo):
     assert len(glob.glob(f"{coincidence_stereo}/*")) == 1
 
 
+def test_get_stereo_events_multimatch(config_gen):
+    """
+    Check if multiple matched events are removed
+    """
+    d = {
+        "obs_id": [1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "tel_id": [1, 2, 1, 1, 3, 1, 1, 2, 3],
+        "event_id": [1, 1, 2, 2, 2, 3, 3, 3, 3],
+    }
+    event_data = pd.DataFrame(data=d)
+    event_data.set_index(["obs_id", "event_id", "tel_id"], inplace=True)
+    data = get_stereo_events(event_data, config_gen)
+    assert np.all(data["multiplicity"] == [2, 2, 2, 2])
+
+
 @pytest.mark.dependency(depends=["test_exist_coincidence_stereo"])
 class TestStereoData:
     def test_get_stereo_events_data(self, coincidence_stereo, config_gen):


### PR DESCRIPTION
the problem was that occasionally two LST-1 images could be assigned to the same MAGIC event. Now in case of such ambiguity both are removed. If there are too many such events >5 the program will exit with error code 11