### PR TITLE
Coincidence method for the MAGIC broken timestamp data

### DIFF
--- a/magicctapipe/io/__init__.py
+++ b/magicctapipe/io/__init__.py
@@ -28,6 +28,7 @@ from .io import (
     resource_file,
     save_pandas_data_in_table,
     telescope_combinations,
+    find_offset,
 )
 
 __all__ = [

--- a/magicctapipe/io/__init__.py
+++ b/magicctapipe/io/__init__.py
@@ -54,4 +54,5 @@ __all__ = [
     "save_pandas_data_in_table",
     "telescope_combinations",
     "resource_file",
+    "find_offset",
 ]

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -46,6 +46,7 @@ __all__ = [
     "save_pandas_data_in_table",
     "telescope_combinations",
     "resource_file",
+    "find_offset",
 ]
 
 logger = logging.getLogger(__name__)

--- a/magicctapipe/scripts/lst1_magic/launch_coincicence_for_brokenGPS.py
+++ b/magicctapipe/scripts/lst1_magic/launch_coincicence_for_brokenGPS.py
@@ -1,0 +1,145 @@
+import pandas as pd
+import glob
+import os
+import matplotlib.pyplot as plt
+
+magic_dir_name = "data/MAGIC/"
+lst_dir_name = "data/LST1/"
+
+magic_t = []
+lst_t = []
+start_l, stop_l = [],[]
+run_l = []
+obs_id_l = []
+start_m, stop_m = [],[]
+run_m = []
+obs_id_m = []
+
+magic_dataset = glob.glob(magic_dir_name+"/*h5")
+magic_dataset = sorted(magic_dataset)
+
+for magic_data in magic_dataset:
+    data_magic = pd.read_hdf(magic_data, key="events/parameters")
+    data_magic["trigger_time"] = data_magic["time_sec"] + data_magic["time_nanosec"] * 1e-9
+    start_m.append(min(data_magic["trigger_time"]))
+    stop_m.append(max(data_magic["trigger_time"]))
+    run_m.append(int(data_magic["obs_id"].mean()))
+
+df_magic = pd.DataFrame({"start":start_m,"stop":stop_m,"run":run_m})
+df_magic = df_magic.groupby("run").agg({"start": "min", "stop": "max"}).reset_index()
+
+print(df_magic)
+
+lst_dataset = glob.glob(lst_dir_name+"/*h5")
+lst_dataset = sorted(lst_dataset)
+
+for lst_data in lst_dataset:
+    data_lst = pd.read_hdf(lst_data, key="/dl1/event/telescope/parameters/LST_LSTCam")
+    start_l.append(min(data_lst["trigger_time"]))
+    stop_l.append(max(data_lst["trigger_time"]))
+    run_l.append(int(data_lst["obs_id"].mean()))
+
+df_lst = pd.DataFrame({"start":start_l,"stop":stop_l,"run":run_l})
+df_lst = df_lst.groupby("run").agg({"start": "min", "stop": "max"}).reset_index()
+
+print(df_lst)
+
+def print_gti(df1, df2):
+    start1_list, stop1_list, start2_list, stop2_list = df1["start"], df1["stop"], df2["start"], df2["stop"]
+    i = 0
+    subrun_1, subrun_2 = [], []
+    for run_ in df1["run"].values:
+        df1_ = df1.query("run==@run_")
+        start1, stop1 = df1_["start"], df1_["stop"]
+        start1, stop1 = float(start1.iloc[0]), float(stop1.iloc[0])
+        j = 0
+        for start2, stop2 in zip(start2_list, stop2_list):
+            obs_time_magic = stop1-start1
+            obs_time_lst = stop2-start2
+            if [obs_time_magic > obs_time_lst]:
+                 s1, e1, s2, e2 = start1,stop1,start2,stop2
+            else:
+                 s1, e1, s2, e2 = start2,stop2,start1,stop1
+            if (s1 < s2) & (s2 < e1) == True:
+                 subrun_1.append(df1_["run"].values[0])
+                 subrun_2.append(df2["run"].values[j])
+            elif (s1 < e2) & (e2 < e1) == True:
+                 subrun_1.append(df1_["run"].values[0])
+                 subrun_2.append(df2["run"].values[j])
+            j = j+1
+        i = i+1
+    return subrun_1, subrun_2
+
+magic_run, lst_run = print_gti(df_magic, df_lst)                    
+df = pd.DataFrame({"magic_run":magic_run,"lst_run":lst_run})
+
+if os.path.isdir("log")==False:
+    os.mkdir("log")
+
+print("-- search subrun coincidence --")
+for i in range(0, len(df)):
+    lst_RunID = str(df["lst_run"][i]).zfill(5)
+    magic_RunID = str(df["magic_run"][i]).zfill(8)
+
+    lst_dataset_group = [l for l in lst_dataset if lst_RunID in l]    
+    magic_dataset_group = [m for m in magic_dataset if magic_RunID in m]
+
+    start_l_subrun, stop_l_subrun = [],[]
+    subrun_l = []
+    
+    for input_file in lst_dataset_group:
+            data_lst = pd.read_hdf(input_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
+            start_l_subrun.append(min(data_lst["trigger_time"]))
+            stop_l_subrun.append(max(data_lst["trigger_time"]))
+            subrun = int(input_file.split(".")[-2])
+            subrun_l.append(subrun)
+    df_lst_subrun = pd.DataFrame({"start":start_l_subrun,"stop":stop_l_subrun,"run":subrun_l})
+    
+    start_m_subrun, stop_m_subrun = [],[]
+    subrun_m = []
+    
+    for input_file in magic_dataset_group:
+            data_magic = pd.read_hdf(input_file, key="events/parameters")
+            data_magic['trigger_time'] = data_magic['time_sec'] + data_magic['time_nanosec'] * 1e-9
+            start_m_subrun.append(min(data_magic["trigger_time"]))
+            stop_m_subrun.append(max(data_magic["trigger_time"]))
+            subrun = int(input_file.split(".")[-2])
+            subrun_m.append(subrun)
+    df_magic_subrun = pd.DataFrame({"start":start_m_subrun,"stop":stop_m_subrun,"run":subrun_m})
+   
+    # Find the corresponding subrun for each file
+    magic_subrun, lst_subrun = print_gti(df_magic_subrun, df_lst_subrun)
+    df_subrun = pd.DataFrame({"magic_subrun":magic_subrun,"lst_subrun":lst_subrun})
+    df_subrun.to_csv("log/subrun_combinations_MAGIC"+magic_RunID+"_LST"+lst_RunID+".txt",sep=" ",index=None)
+
+import subprocess
+
+subrun_combs = glob.glob("log/subrun_combinations_*txt")
+for subrun_comb in subrun_combs:
+    df = pd.read_csv(subrun_comb,sep=" ")
+    pwd = os.getcwd()
+    magic_RunID = subrun_comb.split("_MAGIC")[1].split("_LST")[0]
+    lst_RunID = subrun_comb.split("_LST")[1].split(".txt")[0]
+ 
+    for i in range(len(df)):
+        magic_run = df["magic_subrun"].values[i]
+        lst_run = df["lst_subrun"].values[i]
+        print("--"+str(i+1)+"/"+str(len(df))+"--")
+        print("MAGIC: subrun:",magic_run,"&","LST subrun:",lst_run)
+        magic_run, lst_run = str(magic_run).zfill(3), str(lst_run).zfill(4)
+        magic_path = magic_dir_name+"/dl1_MAGIC.Run"+magic_RunID+"."+magic_run+"/"
+        if os.path.isdir(magic_path)==False:
+            os.mkdir(magic_path)
+            # Make a MAGIC directory for input it in lst_magic_event_coincidence.py
+            os.system("ln -s "+pwd+"/data/MAGIC/dl1_MAGIC.Run"+magic_RunID+"."+magic_run+".h5 "+magic_path)
+        
+        # Run the coincidence script in your local enviroment
+        output = subprocess.run(["python","lst1_magic_event_coincidence.py","-l",lst_dir_name+"/dl1_LST-1.Run"+lst_RunID+"."+lst_run+".h5","-m",magic_path,"-c","./config.yaml","-t","init_time_offset/","-o","data/dl1_coincidence/"+"magic_"+magic_run+"_lst_"+lst_run], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+ 
+        # Make a log file
+        with open("log/coincidence_magic_"+magic_run+"_lst_"+lst_run+".txt","w") as f:
+            f.write(output.stderr)
+        
+        if os.path.isdir(magic_path)==True:
+            os.remove(magic_path+"/dl1_MAGIC.Run"+magic_RunID+"."+magic_run+".h5")
+            os.rmdir(magic_path)

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_event_coincidence.py
@@ -47,6 +47,7 @@ Usage per single LST data file (indicated if you want to do tests):
 $ python lst1_magic_event_coincidence.py
 --input-file-lst dl1/LST/dl1_LST.Run03265.0040.h5
 --input-dir-magic dl1/MAGIC
+(--input-dir_toff time_offset)
 (--output-dir dl1_coincidence)
 (--config-file config.yaml)
 

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
@@ -6,10 +6,36 @@ import os
 import subprocess
 from magicctapipe.io import find_offset
 
+"""
+This script search the time offset for using MAGIC data which the GPS is broken.
+The offset time in such a case is large (few second) and changed gradually (few us/sec). The offset time is known as constant in each subrun.
+In this script we use the subrun files of MAGIC and LST as input files, and make a combination for each event timestamp.
+It will take few tens of minutes to make each npy files. Basically, each MAGIC run contains ~10 subruns and so this step take few hours to be finished. 
+
+Usage:
+$ python lst1_magic_event_coincidence.py data
+
+If you have some runs the input data directory should be separated for each run and use them to save the time, as like,
+data1/LST/
+dl1_LST-1.Run17220.0000.h5 dl1_LST-1.Run17220.0001.h5 ...
+data1/MAGIC/
+dl1_MAGIC.Run05114133.001.h5 dl1_MAGIC.Run05114133.002.h5 ...
+
+data2/LST/
+dl1_LST-1.Run17221.0000.h5 dl1_LST-1.Run17221.0001.h5 ...
+data2/MAGIC/
+dl1_MAGIC.Run05114134.001.h5 dl1_MAGIC.Run05114134.002.h5 ...
+
+$ python lst1_magic_event_coincidence.py data1
+In parallel,
+$ python lst1_magic_event_coincidence.py data2
+...
+"""
+
 file_dl1_dir = sys.argv[1]
 
 magic_run = int(pd.read_hdf(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.*Run*h5")[0], key="events/parameters")["obs_id"].mean())
-lst_run = int(pd.read_hdf(glob.glob(file_dl1_dir+"//LST1/dl1_LST-1.Run*h5")[0], key="/dl1/event/telescope/parameters/LST_LSTCam")["obs_id"].mean())
+lst_run = int(pd.read_hdf(glob.glob(file_dl1_dir+"/LST1/dl1_LST-1.Run*h5")[0], key="/dl1/event/telescope/parameters/LST_LSTCam")["obs_id"].mean())
 magic_run, lst_run = str(magic_run).zfill(8), str(lst_run).zfill(5)
 
 i = 0
@@ -23,7 +49,7 @@ for lst_subrun_file in sorted(glob.glob(file_dl1_dir+"/LST1/dl1_LST*h5")):
     	df_lst_subrun_file_2 = df_lst_subrun_file
     i=i+1
 
-outdir="init_time_offset"
+outdir="time_offset"
 try:
     os.mkdir(outdir)
 except FileExistsError:
@@ -62,6 +88,7 @@ for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+ma
        
             N_start_ = N_begin
             N_end_  = N_start_+15
+            # This output is used for next detailed offset search
             outfile = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_init.npy"
             t_magic_all, N_start_out, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_)
             
@@ -70,6 +97,7 @@ for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+ma
                 time_offset_center = np.load(outfile.replace("MAGIC",M1_M2))[2]
                 N_end_of_run = N_final
                 print("Simultaneous MAGIC+LST1 obs from MAGIC evt index",N_start_,"to",N_end_of_run)
+                # This output have to be loaded by the lst_magic_event_coincidence.py
                 outfile2 = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_"+str(N_end_of_run)+"_detail.npy"
                 t_magic_all, time_offset_best, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_of_run,initial_time_offset=time_offset_center)
                 np.save(outfile2.replace("MAGIC",M1_M2), np.array([t_magic_all, time_offset_best,time_offset_best,n_coincident]))

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pandas as pd
+import sys
+import glob
+import os
+import subprocess
+from magicctapipe.io import find_offset
+
+file_dl1_dir = sys.argv[1]
+
+magic_run = int(pd.read_hdf(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.*Run*h5")[0], key="events/parameters")["obs_id"].mean())
+lst_run = int(pd.read_hdf(glob.glob(file_dl1_dir+"//LST1/dl1_LST-1.Run*h5")[0], key="/dl1/event/telescope/parameters/LST_LSTCam")["obs_id"].mean())
+magic_run, lst_run = str(magic_run).zfill(8), str(lst_run).zfill(5)
+
+i = 0
+for lst_subrun_file in sorted(glob.glob(file_dl1_dir+"/LST1/dl1_LST*h5")):
+    df_lst_subrun_file = pd.read_hdf(lst_subrun_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
+    df_lst_subrun_file = df_lst_subrun_file.query("intensity>100")
+    df_lst_subrun_file = df_lst_subrun_file[["trigger_time","event_type"]]
+    if (i>0):
+    	df_lst_subrun_file_2 = pd.concat([df_lst_subrun_file_2, df_lst_subrun_file])
+    else:
+    	df_lst_subrun_file_2 = df_lst_subrun_file
+    i=i+1
+#lst_merged_file = file_dl1_dir+"/LST1/"+lst_run+".h5"
+#df_lst_subrun_file_2.to_hdf(lst_merged_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
+
+outdir="init_time_offset"
+try:
+    os.mkdir(outdir)
+except FileExistsError:
+    pass
+
+for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+magic_run+".*.h5")):
+    data_magic = pd.read_hdf(magic_subrun_file, key="events/parameters")
+    data_magic = data_magic.query("intensity>100")
+    data_magic['trigger_time'] = data_magic['time_sec'] + data_magic['time_nanosec'] * 1e-9
+    data_magic_m1 = data_magic.query("tel_id==2")
+    data_magic_m1.reset_index(inplace=True)
+    data_magic_m2 = data_magic.query("tel_id==3")
+    data_magic_m2.reset_index(inplace=True)
+    magic_subrun_base = magic_subrun_file.split("/")[-1].split(".h5")[0]
+    
+    data_lst = df_lst_subrun_file_2#pd.read_hdf(lst_merged_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
+    
+    for M1_M2 in ["M1","M2"]:
+        if M1_M2 == "M1":
+            data_magic = data_magic_m1
+        else:
+            data_magic = data_magic_m2
+
+        min_t_magic, max_t_magic = min(data_magic["trigger_time"]), max(data_magic["trigger_time"])
+        min_t_lst, max_t_lst = min(data_lst["trigger_time"]), max(data_lst["trigger_time"])
+
+        if min_t_magic < min_t_lst:
+            if max_t_magic < max_t_lst: 
+                data_magic = data_magic.query("@min_t_lst < trigger_time < @max_t_magic")
+            else: 
+                data_magic = data_magic.query("@min_t_lst < trigger_time < @max_t_lst")
+
+        if len(data_magic)>0:
+            N_begin = data_magic.index[0]
+            N_final = data_magic.index[-1]
+       
+            N_start_ = N_begin#*n_bin
+            N_end_  = N_start_+15
+            outfile = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_init.npy"
+            t_magic_all, N_start_out, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_)
+            
+            if n_coincident!=0:
+                np.save(outfile.replace("MAGIC",M1_M2), np.array([np.mean(t_magic_all), time_offset_best, time_offset_best, n_coincident]))
+                time_offset_center = np.load(outfile.replace("MAGIC",M1_M2))[2]
+                N_end_of_run = N_final #N_end_+(n_bin-15)
+                print("Simultaneous MAGIC+LST1 obs from MAGIC evt index",N_start_,"to",N_end_of_run)
+                outfile2 = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_"+str(N_end_of_run)+"_detail.npy"
+                t_magic_all, time_offset_best, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_of_run,initial_time_offset=time_offset_center)
+                np.save(outfile2.replace("MAGIC",M1_M2), np.array([t_magic_all, time_offset_best,time_offset_best,n_coincident]))

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_find_time_offset.py
@@ -22,8 +22,6 @@ for lst_subrun_file in sorted(glob.glob(file_dl1_dir+"/LST1/dl1_LST*h5")):
     else:
     	df_lst_subrun_file_2 = df_lst_subrun_file
     i=i+1
-#lst_merged_file = file_dl1_dir+"/LST1/"+lst_run+".h5"
-#df_lst_subrun_file_2.to_hdf(lst_merged_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
 
 outdir="init_time_offset"
 try:
@@ -41,8 +39,8 @@ for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+ma
     data_magic_m2.reset_index(inplace=True)
     magic_subrun_base = magic_subrun_file.split("/")[-1].split(".h5")[0]
     
-    data_lst = df_lst_subrun_file_2#pd.read_hdf(lst_merged_file, key="/dl1/event/telescope/parameters/LST_LSTCam")
-    
+    data_lst = df_lst_subrun_file_2
+
     for M1_M2 in ["M1","M2"]:
         if M1_M2 == "M1":
             data_magic = data_magic_m1
@@ -62,7 +60,7 @@ for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+ma
             N_begin = data_magic.index[0]
             N_final = data_magic.index[-1]
        
-            N_start_ = N_begin#*n_bin
+            N_start_ = N_begin
             N_end_  = N_start_+15
             outfile = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_init.npy"
             t_magic_all, N_start_out, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_)
@@ -70,7 +68,7 @@ for magic_subrun_file in sorted(glob.glob(file_dl1_dir+"/MAGIC/dl1_MAGIC.Run"+ma
             if n_coincident!=0:
                 np.save(outfile.replace("MAGIC",M1_M2), np.array([np.mean(t_magic_all), time_offset_best, time_offset_best, n_coincident]))
                 time_offset_center = np.load(outfile.replace("MAGIC",M1_M2))[2]
-                N_end_of_run = N_final #N_end_+(n_bin-15)
+                N_end_of_run = N_final
                 print("Simultaneous MAGIC+LST1 obs from MAGIC evt index",N_start_,"to",N_end_of_run)
                 outfile2 = outdir+"/"+magic_subrun_base+"_"+str(N_start_)+"_"+str(N_end_of_run)+"_detail.npy"
                 t_magic_all, time_offset_best, time_offset_best, n_coincident = find_offset(data_magic,data_lst,N_start=N_start_,N_end=N_end_of_run,initial_time_offset=time_offset_center)


### PR DESCRIPTION
We made a new function find_offset, which find and output the time dependent time offset value between MAGIC and LST (as numpy binary files). The lst1_magic_find_time_offset.py is the script for make it each subrun set. 
We added the new function to magicctapipe and make changes for lst1_magic_event_coincidence.py to load the time offset files and correct the MAGIC timestamp (use --input-dir_toff option for activate it). To find the corresponding subrun files between MAGIC and LST each other and input it to the lst1_magic_event_coincidence.py, we made a script launch_coincicence_for_brokenGPS.py. The usage is below.


== Make time offset search ==

Usage:
$ python lst1_magic_find_time_offset.py data

If you have some runs the input data directory should be separated for each run and use them to save the time, as like,
data1/LST/
dl1_LST-1.Run17220.0000.h5 dl1_LST-1.Run17220.0001.h5 ...
data1/MAGIC/
dl1_MAGIC.Run05114133.001.h5 dl1_MAGIC.Run05114133.002.h5 ...

data2/LST/
dl1_LST-1.Run17221.0000.h5 dl1_LST-1.Run17221.0001.h5 ...
data2/MAGIC/
dl1_MAGIC.Run05114134.001.h5 dl1_MAGIC.Run05114134.002.h5 ...

$ python lst1_magic_find_time_offset.py data1
In parallel,
$ python lst1_magic_find_time_offset.py data2

# It will take a few tens of minutes to make each npy file. Basically, each MAGIC run contains ~10 subruns and so this step takes a few hours to be finished.

== Run the lst_magic_event_coincidence.py ==

Run the coincidence script using npy files made before step.
The input files should be corresponding subrun with each other. you can use attached file ($ python launch_coincicence_for_brokenGPS.py.

Then you will find many coincided dl1 files, you can merge them with merge_hdf_files.py for the next dl1 to dl2 step.