### PR TITLE
Pin version of micromamba.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       - name: mamba setup
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '2.0.0-0'
           environment-file: environment.yml
           cache-downloads: true
 


### PR DESCRIPTION
Tests are failing because of a problem in micromamba, see https://github.com/mamba-org/setup-micromamba/issues/225. Version is now pinned, to be removed when the problem is solved on micromamba's side.