### PR TITLE
Fixed DL3 creation complaining about mismatch in binning.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,6 @@ repos:
                 .*__init__.py|
                 .*/tests/.*
             )$
+
+default_language_version:
+    python: python3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
             )$
 
 default_language_version:
-    python: python3.11
+    python: python3

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -1325,10 +1325,14 @@ def load_irf_files(input_dir_irf):
             unique_bins = np.unique(irf_data[key], axis=0)
 
             if len(unique_bins) > 1:
-                if not np.all(np.abs(unique_bins - unique_bins[0]) < unique_bins[0]*1.e-15):
+                if not np.all(
+                    np.abs(unique_bins - unique_bins[0]) < unique_bins[0] * 1.0e-15
+                ):
                     raise RuntimeError(f"The binning of '{key}' do not match.")
-		else:
-                    logger.warning(f"The bins of '{key}' do not match, but the difference is within numerical precision, ignoring")
+                else:
+                    logger.warning(
+                        f"The bins of '{key}' do not match, but the difference is within numerical precision, ignoring"
+                    )
                     irf_data[key] = unique_bins[0]
 
             else:

--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -1325,7 +1325,11 @@ def load_irf_files(input_dir_irf):
             unique_bins = np.unique(irf_data[key], axis=0)
 
             if len(unique_bins) > 1:
-                raise RuntimeError(f"The binning of '{key}' do not match.")
+                if not np.all(np.abs(unique_bins - unique_bins[0]) < unique_bins[0]*1.e-15):
+                    raise RuntimeError(f"The binning of '{key}' do not match.")
+		else:
+                    logger.warning(f"The bins of '{key}' do not match, but the difference is within numerical precision, ignoring")
+                    irf_data[key] = unique_bins[0]
 
             else:
                 # Set the unique bins


### PR DESCRIPTION
It sometimes happened that the IRF files have different bin ranges saved despite using the same input card. The difference is very small, comparable to the numerical accuracy of double precision. I saw it in the files processed in CNAF and my suspicion is that it comes from inhomogenuity of machines over which the code was run. Now if different binning is detected, it checks also if the relative difference exceeds somewhere 10^-15 and only then raises an error.