### PR TITLE
fix dropped cols

### DIFF
--- a/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/database_production/nsb_to_h5.py
+++ b/magicctapipe/scripts/lst1_magic/semi_automatic_scripts/database_production/nsb_to_h5.py
@@ -65,6 +65,11 @@ def collect_nsb(df_LST):
             "processed_lstchain_file",
             "tailcut",
             "error_code_nsb",
+            "ra",
+            "dec",
+            "MC_dec",
+            "point_source",
+            "wobble_offset",
         ]
     ]
     return df_LST


### PR DESCRIPTION
Some cols were dropped in the nsb?to?h5 step and recovered when evaluating coords (because ths script was created when these cols were not there and there was a 'reordering' of the columsn using a mask). Now removing this dropping and recovering