### PR TITLE
changes to use get_stereo_events everywhere instead of get_stereo_events_old

### DIFF
--- a/magicctapipe/io/io.py
+++ b/magicctapipe/io/io.py
@@ -783,7 +783,7 @@ def load_magic_dl1_data_files(input_dir, config):
 
 
 def load_train_data_files(
-    input_dir, offaxis_min=None, offaxis_max=None, true_event_class=None
+    input_dir, config, offaxis_min=None, offaxis_max=None, true_event_class=None
 ):
     """
     Loads DL1-stereo data files and separates the shower events per
@@ -793,6 +793,8 @@ def load_train_data_files(
     ----------
     input_dir : str
         Path to a directory where input DL1-stereo files are stored
+    config : dict
+        Yaml file with information about the telescope IDs.
     offaxis_min : str, optional
         Minimum shower off-axis angle allowed, whose format should be
         acceptable by `astropy.units.quantity.Quantity`
@@ -814,12 +816,8 @@ def load_train_data_files(
         If any DL1-stereo data files are not found in the input
         directory
     """
-    TEL_COMBINATIONS = {
-        "LST1_M1": [1, 2],  # combo_type = 0
-        "LST1_M1_M2": [1, 2, 3],  # combo_type = 1
-        "LST1_M2": [1, 3],  # combo_type = 2
-        "M1_M2": [2, 3],  # combo_type = 3
-    }  # TODO: REMOVE WHEN SWITCHING TO THE NEW RFs IMPLEMENTTATION (1 RF PER TELESCOPE)
+    _, TEL_COMBINATIONS = telescope_combinations(config)
+    # TEL_COMBINATIONS = {k.replace("MAGIC-II", "M2").replace("MAGIC-I","M1").replace("LST-","LST"): v for k,v in TEL_COMBINATIONS.items()}
 
     # Find the input files
     file_mask = f"{input_dir}/dl1_stereo_*.h5"
@@ -858,7 +856,7 @@ def load_train_data_files(
     if true_event_class is not None:
         event_data["true_event_class"] = true_event_class
 
-    event_data = get_stereo_events_old(event_data, group_index=GROUP_INDEX_TRAIN)
+    event_data = get_stereo_events(event_data, config, group_index=GROUP_INDEX_TRAIN)
 
     data_train = {}
 
@@ -959,7 +957,9 @@ def load_train_data_files_tel(
     return data_train
 
 
-def load_mc_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
+def load_mc_dl2_data_file(
+    input_file, config, quality_cuts, event_type, weight_type_dl2
+):
     """
     Loads a MC DL2 data file for creating the IRFs.
 
@@ -967,6 +967,8 @@ def load_mc_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2)
     ----------
     input_file : str
         Path to an input MC DL2 data file
+    config : dict
+        Yaml file with information about the telescope IDs.
     quality_cuts : str
         Quality cuts applied to the input events
     event_type : str
@@ -999,7 +1001,7 @@ def load_mc_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2)
     df_events.set_index(["obs_id", "event_id", "tel_id"], inplace=True)
     df_events.sort_index(inplace=True)
 
-    df_events = get_stereo_events_old(df_events, quality_cuts)
+    df_events = get_stereo_events(df_events, config, quality_cuts)
 
     logger.info(f"\nExtracting the events of the '{event_type}' type...")
 
@@ -1090,7 +1092,7 @@ def load_mc_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2)
     return event_table, pointing, sim_info
 
 
-def load_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
+def load_dl2_data_file(input_file, config, quality_cuts, event_type, weight_type_dl2):
     """
     Loads a DL2 data file for processing to DL3.
 
@@ -1098,6 +1100,8 @@ def load_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
     ----------
     input_file : str
         Path to an input DL2 data file
+    config : dict
+        Yaml file with information about the telescope IDs.
     quality_cuts : str
         Quality cuts applied to the input events
     event_type : str
@@ -1130,7 +1134,7 @@ def load_dl2_data_file(input_file, quality_cuts, event_type, weight_type_dl2):
     event_data.set_index(["obs_id", "event_id", "tel_id"], inplace=True)
     event_data.sort_index(inplace=True)
 
-    event_data = get_stereo_events_old(event_data, quality_cuts)
+    event_data = get_stereo_events(event_data, config, quality_cuts)
 
     logger.info(f"\nExtracting the events of the '{event_type}' type...")
 

--- a/magicctapipe/io/tests/test_io.py
+++ b/magicctapipe/io/tests/test_io.py
@@ -313,32 +313,35 @@ class TestStereoMC:
             assert np.all(data["intensity"] > 50)
             assert len(data) > 0
 
-    def test_load_train_data_files(self, p_stereo, gamma_stereo):
+    def test_load_train_data_files(self, p_stereo, gamma_stereo, config_gen):
         """
         Check dictionary of the combo types
         """
 
         for stereo in [p_stereo, gamma_stereo]:
-            events = load_train_data_files(str(stereo[0]))
+            events = load_train_data_files(str(stereo[0]), config_gen)
             assert list(events.keys()) == ["LST1_M1", "LST1_M1_M2", "LST1_M2", "M1_M2"]
             data = events["LST1_M1"]
             assert np.all(data["combo_type"] == 0)
             assert "off_axis" in data.columns
             assert "true_event_class" not in data.columns
 
-    def test_load_train_data_files_off(self, gamma_stereo):
+    def test_load_train_data_files_off(self, gamma_stereo, config_gen):
         """
         Check off-axis cut
         """
         events = load_train_data_files(
-            str(gamma_stereo[0]), offaxis_min="0.2 deg", offaxis_max="0.5 deg"
+            str(gamma_stereo[0]),
+            config_gen,
+            offaxis_min="0.2 deg",
+            offaxis_max="0.5 deg",
         )
         data = events["LST1_M1"]
         assert np.all(data["off_axis"] >= 0.2)
         assert np.all(data["off_axis"] <= 0.5)
         assert len(data) > 0
 
-    def test_load_train_data_files_exc(self, temp_train_exc):
+    def test_load_train_data_files_exc(self, temp_train_exc, config_gen):
         """
         Check on exceptions
         """
@@ -347,7 +350,7 @@ class TestStereoMC:
             FileNotFoundError,
             match="Could not find any DL1-stereo data files in the input directory.",
         ):
-            _ = load_train_data_files(str(temp_train_exc))
+            _ = load_train_data_files(str(temp_train_exc), config_gen)
 
     def test_load_train_data_files_tel(self, p_stereo, gamma_stereo, config_gen):
         """
@@ -408,14 +411,14 @@ def test_exist_dl2_mc(p_dl2, gamma_dl2):
 
 @pytest.mark.dependency(depends=["test_exist_dl2_mc"])
 class TestDL2MC:
-    def test_load_mc_dl2_data_file(self, p_dl2, gamma_dl2):
+    def test_load_mc_dl2_data_file(self, p_dl2, gamma_dl2, config_gen):
         """
         Checks on default loading
         """
         dl2_mc = [p for p in gamma_dl2.glob("*")] + [p for p in p_dl2.glob("*")]
         for file in dl2_mc:
             data, point, _ = load_mc_dl2_data_file(
-                str(file), "width>0", "software", "simple"
+                str(file), config_gen, "width>0", "software", "simple"
             )
             assert "pointing_alt" in data.colnames
             assert "theta" in data.colnames
@@ -424,31 +427,31 @@ class TestDL2MC:
             assert point[0] >= 0
             assert point[0] <= 90
 
-    def test_load_mc_dl2_data_file_cut(self, p_dl2, gamma_dl2):
+    def test_load_mc_dl2_data_file_cut(self, config_gen, p_dl2, gamma_dl2):
         """
         Check on quality cuts
         """
         dl2_mc = [p for p in gamma_dl2.glob("*")] + [p for p in p_dl2.glob("*")]
         for file in dl2_mc:
             data, _, _ = load_mc_dl2_data_file(
-                str(file), "gammaness>0.1", "software", "simple"
+                str(file), config_gen, "gammaness>0.1", "software", "simple"
             )
             assert np.all(data["gammaness"] > 0.1)
             assert len(data) > 0
 
-    def test_load_mc_dl2_data_file_opt(self, p_dl2, gamma_dl2):
+    def test_load_mc_dl2_data_file_opt(self, p_dl2, gamma_dl2, config_gen):
         """
         Check on event_type
         """
         dl2_mc = [p for p in gamma_dl2.glob("*")] + [p for p in p_dl2.glob("*")]
         for file in dl2_mc:
             data_s, _, _ = load_mc_dl2_data_file(
-                str(file), "width>0", "software", "simple"
+                str(file), config_gen, "width>0", "software", "simple"
             )
             assert np.all(data_s["combo_type"] < 3)
             assert len(data_s) > 0
 
-    def test_load_mc_dl2_data_file_exc(self, p_dl2, gamma_dl2):
+    def test_load_mc_dl2_data_file_exc(self, p_dl2, gamma_dl2, config_gen):
         """
         Check on event_type exceptions
         """
@@ -460,7 +463,7 @@ class TestDL2MC:
                 match=f"Unknown event type '{event_type}'.",
             ):
                 _, _, _ = load_mc_dl2_data_file(
-                    str(file), "width>0", event_type, "simple"
+                    str(file), config_gen, "width>0", event_type, "simple"
                 )
 
     def test_get_dl2_mean_mc(self, p_dl2, gamma_dl2):
@@ -733,13 +736,13 @@ def test_exist_dl2(real_dl2):
 
 @pytest.mark.dependency(depends=["test_exist_dl2"])
 class TestDL2Data:
-    def test_load_dl2_data_file(self, real_dl2):
+    def test_load_dl2_data_file(self, real_dl2, config_gen):
         """
         Checks on default loading
         """
         for file in real_dl2.glob("*"):
             data, on, dead = load_dl2_data_file(
-                str(file), "width>0", "software", "simple"
+                str(file), config_gen, "width>0", "software", "simple"
             )
             assert "pointing_alt" in data.colnames
             assert "timestamp" in data.colnames
@@ -748,29 +751,29 @@ class TestDL2Data:
             assert on > 0
             assert dead > 0
 
-    def test_load_dl2_data_file_cut(self, real_dl2):
+    def test_load_dl2_data_file_cut(self, real_dl2, config_gen):
         """
         Check on quality cuts
         """
         for file in real_dl2.glob("*"):
             data, _, _ = load_dl2_data_file(
-                str(file), "gammaness<0.9", "software", "simple"
+                str(file), config_gen, "gammaness<0.9", "software", "simple"
             )
             assert np.all(data["gammaness"] < 0.9)
             assert len(data) > 0
 
-    def test_load_dl2_data_file_opt(self, real_dl2):
+    def test_load_dl2_data_file_opt(self, real_dl2, config_gen):
         """
         Check on event_type
         """
         for file in real_dl2.glob("*"):
             data_s, _, _ = load_dl2_data_file(
-                str(file), "width>0", "software", "simple"
+                str(file), config_gen, "width>0", "software", "simple"
             )
             assert np.all(data_s["combo_type"] < 3)
             assert len(data_s) > 0
 
-    def test_load_dl2_data_file_exc(self, real_dl2):
+    def test_load_dl2_data_file_exc(self, real_dl2, config_gen):
         """
         Check on event_type exceptions
         """
@@ -780,7 +783,9 @@ class TestDL2Data:
                 ValueError,
                 match=f"Unknown event type '{event_type}'.",
             ):
-                _, _, _ = load_dl2_data_file(str(file), "width>0", event_type, "simple")
+                _, _, _ = load_dl2_data_file(
+                    str(file), config_gen, "width>0", event_type, "simple"
+                )
 
     def test_get_dl2_mean_real(self, real_dl2):
         """

--- a/magicctapipe/io/tests/test_io_monly.py
+++ b/magicctapipe/io/tests/test_io_monly.py
@@ -80,25 +80,30 @@ class TestStereoMC:
             assert np.all(data["intensity"] > 50)
             assert len(data) > 0
 
-    def test_load_train_data_files(self, p_stereo_monly, gamma_stereo_monly):
+    def test_load_train_data_files(
+        self, p_stereo_monly, gamma_stereo_monly, config_gen
+    ):
         """
         Check dictionary
         """
 
         for stereo in [p_stereo_monly, gamma_stereo_monly]:
-            events = load_train_data_files(str(stereo[0]))
+            events = load_train_data_files(str(stereo[0]), config_gen)
             assert list(events.keys()) == ["M1_M2"]
             data = events["M1_M2"]
             assert np.all(data["combo_type"] == 3)
             assert "off_axis" in data.columns
             assert "true_event_class" not in data.columns
 
-    def test_load_train_data_files_off(self, gamma_stereo_monly):
+    def test_load_train_data_files_off(self, gamma_stereo_monly, config_gen):
         """
         Check off-axis cut
         """
         events = load_train_data_files(
-            str(gamma_stereo_monly[0]), offaxis_min="0.2 deg", offaxis_max="0.5 deg"
+            str(gamma_stereo_monly[0]),
+            config_gen,
+            offaxis_min="0.2 deg",
+            offaxis_max="0.5 deg",
         )
         data = events["M1_M2"]
         assert np.all(data["off_axis"] >= 0.2)
@@ -156,7 +161,7 @@ def test_exist_dl2_mc(p_dl2_monly, gamma_dl2_monly):
 
 @pytest.mark.dependency(depends=["test_exist_dl2_mc"])
 class TestDL2MC:
-    def test_load_mc_dl2_data_file(self, p_dl2_monly, gamma_dl2_monly):
+    def test_load_mc_dl2_data_file(self, p_dl2_monly, gamma_dl2_monly, config_gen):
         """
         Checks on default loading
         """
@@ -165,7 +170,7 @@ class TestDL2MC:
         ]
         for file in dl2_mc:
             data, point, _ = load_mc_dl2_data_file(
-                str(file), "width>0", "magic_only", "simple"
+                str(file), config_gen, "width>0", "magic_only", "simple"
             )
             assert "pointing_alt" in data.colnames
             assert "theta" in data.colnames
@@ -174,7 +179,7 @@ class TestDL2MC:
             assert point[0] >= 0
             assert point[0] <= 90
 
-    def test_load_mc_dl2_data_file_cut(self, p_dl2_monly, gamma_dl2_monly):
+    def test_load_mc_dl2_data_file_cut(self, p_dl2_monly, gamma_dl2_monly, config_gen):
         """
         Check on quality cuts
         """
@@ -183,12 +188,12 @@ class TestDL2MC:
         ]
         for file in dl2_mc:
             data, _, _ = load_mc_dl2_data_file(
-                str(file), "gammaness>0.1", "magic_only", "simple"
+                str(file), config_gen, "gammaness>0.1", "magic_only", "simple"
             )
             assert np.all(data["gammaness"] > 0.1)
             assert len(data) > 0
 
-    def test_load_mc_dl2_data_file_opt(self, p_dl2_monly, gamma_dl2_monly):
+    def test_load_mc_dl2_data_file_opt(self, p_dl2_monly, gamma_dl2_monly, config_gen):
         """
         Check on event_type
         """
@@ -198,13 +203,13 @@ class TestDL2MC:
         for file in dl2_mc:
 
             data_m, _, _ = load_mc_dl2_data_file(
-                str(file), "width>0", "magic_only", "simple"
+                str(file), config_gen, "width>0", "magic_only", "simple"
             )
 
             assert np.all(data_m["combo_type"] == 3)
             assert len(data_m) > 0
 
-    def test_load_mc_dl2_data_file_exc(self, p_dl2_monly, gamma_dl2_monly):
+    def test_load_mc_dl2_data_file_exc(self, p_dl2_monly, gamma_dl2_monly, config_gen):
         """
         Check on event_type exceptions
         """
@@ -218,7 +223,7 @@ class TestDL2MC:
                 match=f"Unknown event type '{event_type}'.",
             ):
                 _, _, _ = load_mc_dl2_data_file(
-                    str(file), "width>0", event_type, "simple"
+                    str(file), config_gen, "width>0", event_type, "simple"
                 )
 
     def test_get_dl2_mean_mc(self, p_dl2_monly, gamma_dl2_monly):
@@ -410,13 +415,13 @@ def test_exist_dl2(real_dl2_monly):
 
 @pytest.mark.dependency(depends=["test_exist_dl2"])
 class TestDL2Data:
-    def test_load_dl2_data_file(self, real_dl2_monly):
+    def test_load_dl2_data_file(self, real_dl2_monly, config_gen):
         """
         Checks on default loading
         """
         for file in real_dl2_monly.glob("*"):
             data, on, dead = load_dl2_data_file(
-                str(file), "width>0", "magic_only", "simple"
+                str(file), config_gen, "width>0", "magic_only", "simple"
             )
             assert "pointing_alt" in data.colnames
             assert "timestamp" in data.colnames
@@ -425,31 +430,31 @@ class TestDL2Data:
             assert on > 0
             assert dead > 0
 
-    def test_load_dl2_data_file_cut(self, real_dl2_monly):
+    def test_load_dl2_data_file_cut(self, real_dl2_monly, config_gen):
         """
         Check on quality cuts
         """
         for file in real_dl2_monly.glob("*"):
             data, _, _ = load_dl2_data_file(
-                str(file), "gammaness<0.9", "magic_only", "simple"
+                str(file), config_gen, "gammaness<0.9", "magic_only", "simple"
             )
             assert np.all(data["gammaness"] < 0.9)
             assert len(data) > 0
 
-    def test_load_dl2_data_file_opt(self, real_dl2_monly):
+    def test_load_dl2_data_file_opt(self, real_dl2_monly, config_gen):
         """
         Check on event_type
         """
         for file in real_dl2_monly.glob("*"):
 
             data_m, _, _ = load_dl2_data_file(
-                str(file), "width>0", "magic_only", "simple"
+                str(file), config_gen, "width>0", "magic_only", "simple"
             )
 
             assert np.all(data_m["combo_type"] == 3)
             assert len(data_m) > 0
 
-    def test_load_dl2_data_file_exc(self, real_dl2_monly):
+    def test_load_dl2_data_file_exc(self, real_dl2_monly, config_gen):
         """
         Check on event_type exceptions
         """
@@ -459,7 +464,9 @@ class TestDL2Data:
                 ValueError,
                 match=f"Unknown event type '{event_type}'.",
             ):
-                _, _, _ = load_dl2_data_file(str(file), "width>0", event_type, "simple")
+                _, _, _ = load_dl2_data_file(
+                    str(file), config_gen, "width>0", event_type, "simple"
+                )
 
     def test_get_dl2_mean_real(self, real_dl2_monly):
         """

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_create_irf.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_create_irf.py
@@ -135,7 +135,7 @@ def create_irf(
     logger.info(f"\nInput gamma MC DL2 data file: {input_file_gamma}")
 
     event_table_gamma, pnt_gamma, sim_info_gamma = load_mc_dl2_data_file(
-        input_file_gamma, quality_cuts, event_type, weight_type_dl2
+        input_file_gamma, config, quality_cuts, event_type, weight_type_dl2
     )
     viewcone = sim_info_gamma.viewcone_max.to_value(
         "deg"
@@ -210,7 +210,7 @@ def create_irf(
         logger.info(f"\nInput proton MC DL2 data file: {input_file_proton}")
 
         event_table_proton, pnt_proton, sim_info_proton = load_mc_dl2_data_file(
-            input_file_proton, quality_cuts, event_type, weight_type_dl2
+            input_file_proton, config, quality_cuts, event_type, weight_type_dl2
         )
 
         if any(pnt_proton != pnt_gamma):
@@ -223,7 +223,7 @@ def create_irf(
         logger.info(f"\nInput electron MC DL2 data file: {input_file_electron}")
 
         event_table_electron, pnt_electron, sim_info_electron = load_mc_dl2_data_file(
-            input_file_electron, quality_cuts, event_type, weight_type_dl2
+            input_file_electron, config, quality_cuts, event_type, weight_type_dl2
         )
 
         if any(pnt_electron != pnt_gamma):

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl1_stereo_to_dl2.py
@@ -25,12 +25,13 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import yaml
 from astropy import units as u
 from astropy.coordinates import AltAz, SkyCoord, angular_separation
 from ctapipe.coordinates import TelescopeFrame
 from ctapipe.instrument import SubarrayDescription
 
-from magicctapipe.io import get_stereo_events_old, save_pandas_data_in_table
+from magicctapipe.io import get_stereo_events, save_pandas_data_in_table
 from magicctapipe.reco import DispRegressor, EnergyRegressor, EventClassifier
 
 __all__ = ["apply_rfs", "reconstruct_arrival_direction", "dl1_stereo_to_dl2"]
@@ -247,7 +248,7 @@ def reconstruct_arrival_direction(event_data, tel_descriptions):
     return reco_params
 
 
-def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
+def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir, config):
     """
     Processes DL1-stereo events and reconstructs the DL2 parameters with
     trained RFs.
@@ -260,6 +261,8 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
         Path to a directory where trained RFs are stored
     output_dir : str
         Path to a directory where to save an output DL2 data file
+    config : dict
+        Yaml file with information about the telescope IDs.
     """
 
     # Load the input DL1-stereo data file
@@ -272,7 +275,7 @@ def dl1_stereo_to_dl2(input_file_dl1, input_dir_rfs, output_dir):
     is_simulation = "true_energy" in event_data.columns
     logger.info(f"\nIs simulation: {is_simulation}")
 
-    event_data = get_stereo_events_old(event_data)
+    event_data = get_stereo_events(event_data, config)
 
     subarray = SubarrayDescription.from_hdf(input_file_dl1)
     tel_descriptions = subarray.tel
@@ -434,10 +437,22 @@ def main():
         help="Path to a directory where to save an output DL2 data file",
     )
 
+    parser.add_argument(
+        "--config-file",
+        "-c",
+        dest="config_file",
+        type=str,
+        default="./config.yaml",
+        help="Path to a configuration file",
+    )
+
     args = parser.parse_args()
 
+    with open(args.config_file, "rb") as f:
+        config = yaml.safe_load(f)
+
     # Process the input data
-    dl1_stereo_to_dl2(args.input_file_dl1, args.input_dir_rfs, args.output_dir)
+    dl1_stereo_to_dl2(args.input_file_dl1, args.input_dir_rfs, args.output_dir, config)
 
     logger.info("\nDone.")
 

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_dl2_to_dl3.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_dl2_to_dl3.py
@@ -100,7 +100,7 @@ def dl2_to_dl3(input_file_dl2, input_dir_irf, output_dir, config):
     dl2_weight_type = extra_header["DL2_WEIG"]
 
     event_table, on_time, deadc = load_dl2_data_file(
-        input_file_dl2, quality_cuts, event_type, dl2_weight_type
+        input_file_dl2, config, quality_cuts, event_type, dl2_weight_type
     )
 
     # Calculate the mean pointing direction for the target point of the

--- a/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
+++ b/magicctapipe/scripts/lst1_magic/lst1_magic_train_rfs.py
@@ -130,7 +130,7 @@ def train_energy_regressor(input_dir, output_dir, config, use_unsigned_features=
     logger.info(f"\nInput directory: {input_dir}")
 
     event_data_train = load_train_data_files(
-        input_dir, gamma_offaxis["min"], gamma_offaxis["max"]
+        input_dir, config, gamma_offaxis["min"], gamma_offaxis["max"]
     )
 
     # Configure the energy regressor
@@ -202,7 +202,7 @@ def train_disp_regressor(input_dir, output_dir, config, use_unsigned_features=Fa
     logger.info(f"\nInput directory: {input_dir}")
 
     event_data_train = load_train_data_files(
-        input_dir, gamma_offaxis["min"], gamma_offaxis["max"]
+        input_dir, config, gamma_offaxis["min"], gamma_offaxis["max"]
     )
 
     # Configure the DISP regressor
@@ -278,14 +278,18 @@ def train_event_classifier(
     logger.info(f"\nInput gamma MC directory: {input_dir_gamma}")
 
     event_data_gamma = load_train_data_files(
-        input_dir_gamma, gamma_offaxis["min"], gamma_offaxis["max"], EVENT_CLASS_GAMMA
+        input_dir_gamma,
+        config,
+        gamma_offaxis["min"],
+        gamma_offaxis["max"],
+        EVENT_CLASS_GAMMA,
     )
 
     # Load the input proton MC data files
     logger.info(f"\nInput proton MC directory: {input_dir_proton}")
 
     event_data_proton = load_train_data_files(
-        input_dir_proton, true_event_class=EVENT_CLASS_PROTON
+        input_dir_proton, config, true_event_class=EVENT_CLASS_PROTON
     )
 
     # Configure the event classifier

--- a/notebooks/check_irfs_from_dl2.ipynb
+++ b/notebooks/check_irfs_from_dl2.ipynb
@@ -8,10 +8,11 @@
    "source": [
     "import itertools\n",
     "import operator\n",
+    "import yaml\n",
     "\n",
     "import numpy as np\n",
     "from astropy import units as u\n",
-    "from magicctapipe.io import load_mc_dl2_data_file\n",
+    "from magicctapipe.io import load_mc_dl2_data_file, resource_file\n",
     "from matplotlib import gridspec\n",
     "from matplotlib import pyplot as plt\n",
     "from pyirf.benchmarks import angular_resolution, energy_bias_resolution\n",
@@ -31,7 +32,10 @@
     ")\n",
     "\n",
     "# Get the pyplot default color cycle\n",
-    "colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]"
+    "colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]\n",
+    "\n",
+    "with open(resource_file(\"test_config.yaml\"), \"rb\") as f:\n",
+    "    config = yaml.safe_load(f)"
    ]
   },
   {
@@ -43,66 +47,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Input file: /home/yoshiki.ohtani/lstmagic/mc/zd40deg_az90deg/magic_only_analysis/4.dl1_stereo_to_dl2/data/gamma/dl2/merged/dl2_magic_only_gamma_zd_40.0deg_az_90.0deg_LST-1_MAGIC_run401_to_1000.h5\n",
-      "\n",
-      "Quality cuts: (disp_diff_mean < 0.22360679774997896)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "In total 477199 stereo events are found:\n",
-      "    M1_M2 (type 0): 477199 events (100.0%)\n",
-      "    LST1_M1 (type 1): 0 events (0.0%)\n",
-      "    LST1_M2 (type 2): 0 events (0.0%)\n",
-      "    LST1_M1_M2 (type 3): 0 events (0.0%) \n",
-      "\n",
-      "Extracting the events of the 'magic_only' type...\n",
-      "--> 477199 stereo events\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><i>QTable length=5</i>\n",
-       "<table id=\"table139678517705504\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>obs_id</th><th>event_id</th><th>combo_type</th><th>multiplicity</th><th>true_energy</th><th>true_alt</th><th>true_az</th><th>pointing_alt</th><th>pointing_az</th><th>reco_energy</th><th>reco_alt</th><th>reco_az</th><th>gammaness</th><th>theta</th><th>true_source_fov_offset</th><th>reco_source_fov_offset</th></tr></thead>\n",
-       "<thead><tr><th></th><th></th><th></th><th></th><th>TeV</th><th>deg</th><th>deg</th><th>rad</th><th>rad</th><th>TeV</th><th>deg</th><th>deg</th><th></th><th>deg</th><th>deg</th><th>deg</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>401</td><td>13605</td><td>0</td><td>2</td><td>0.6236247420310974</td><td>50.0000002530119</td><td>89.999995674289</td><td>0.8656833474915151</td><td>1.5707963705062864</td><td>0.4744231109606334</td><td>50.041107128533184</td><td>89.94039159450904</td><td>0.9444166666666667</td><td>0.05618173805480561</td><td>0.3999980470153132</td><td>0.4427783699442063</td></tr>\n",
-       "<tr><td>401</td><td>13606</td><td>0</td><td>2</td><td>0.6236247420310974</td><td>50.0000002530119</td><td>89.999995674289</td><td>0.8656833474915151</td><td>1.5707963705062864</td><td>0.47912279374902145</td><td>50.04249329803637</td><td>89.98580191417803</td><td>0.9217142857142857</td><td>0.043460612903663334</td><td>0.3999980470153132</td><td>0.4425859283445896</td></tr>\n",
-       "<tr><td>401</td><td>13609</td><td>0</td><td>2</td><td>0.6236247420310974</td><td>50.0000002530119</td><td>89.999995674289</td><td>0.8656833474915151</td><td>1.5707963705062864</td><td>0.5101104743940791</td><td>49.978012862994944</td><td>90.00819949231237</td><td>0.9770833333333333</td><td>0.022611188849645893</td><td>0.3999980470153132</td><td>0.3780476975549167</td></tr>\n",
-       "<tr><td>401</td><td>15600</td><td>0</td><td>2</td><td>0.21664372086524963</td><td>50.0000002530119</td><td>89.999995674289</td><td>0.8656833474915151</td><td>1.5707963705062864</td><td>0.22541553850117652</td><td>49.753345074962205</td><td>89.98526109221594</td><td>0.9119166666666667</td><td>0.2468378825881244</td><td>0.3999980470153132</td><td>0.1536392884692065</td></tr>\n",
-       "<tr><td>401</td><td>20201</td><td>0</td><td>2</td><td>0.5037534236907959</td><td>50.0000002530119</td><td>89.999995674289</td><td>0.8656833474915151</td><td>1.5707963705062864</td><td>0.48534478334401276</td><td>50.06186371462703</td><td>90.09448415336732</td><td>0.97875</td><td>0.08666720138167297</td><td>0.3999980470153132</td><td>0.4658650375745834</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<QTable length=5>\n",
-       "obs_id event_id combo_type multiplicity ...     gammaness             theta         true_source_fov_offset reco_source_fov_offset\n",
-       "                                        ...                            deg                   deg                    deg          \n",
-       "int64   int64     int64       int64     ...      float64             float64               float64                float64        \n",
-       "------ -------- ---------- ------------ ... ------------------ -------------------- ---------------------- ----------------------\n",
-       "   401    13605          0            2 ... 0.9444166666666667  0.05618173805480561     0.3999980470153132     0.4427783699442063\n",
-       "   401    13606          0            2 ... 0.9217142857142857 0.043460612903663334     0.3999980470153132     0.4425859283445896\n",
-       "   401    13609          0            2 ... 0.9770833333333333 0.022611188849645893     0.3999980470153132     0.3780476975549167\n",
-       "   401    15600          0            2 ... 0.9119166666666667   0.2468378825881244     0.3999980470153132     0.1536392884692065\n",
-       "   401    20201          0            2 ...            0.97875  0.08666720138167297     0.3999980470153132     0.4658650375745834"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ================\n",
     "# === Settings ===\n",
@@ -124,7 +71,7 @@
     "\n",
     "# Load the input file\n",
     "data_magic, _, sim_info_magic = load_mc_dl2_data_file(\n",
-    "    input_file, quality_cuts, event_type=\"magic_only\", weight_type_dl2=\"simple\"\n",
+    "    input_file, config, quality_cuts, event_type=\"magic_only\", weight_type_dl2=\"simple\"\n",
     ")\n",
     "\n",
     "# Show the data table\n",
@@ -221,7 +168,11 @@
     "\n",
     "# Load the input file\n",
     "data_mlst, _, sim_info_mlst = load_mc_dl2_data_file(\n",
-    "    input_file, quality_cuts, event_type=\"software_only_3tel\", weight_type_dl2=\"simple\"\n",
+    "    input_file,\n",
+    "    config,\n",
+    "    quality_cuts,\n",
+    "    event_type=\"software_only_3tel\",\n",
+    "    weight_type_dl2=\"simple\",\n",
     ")\n",
     "\n",
     "# Show the data table\n",
@@ -1393,9 +1344,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lstmagic",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "lstmagic"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1407,7 +1358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/check_signal_from_dl2.ipynb
+++ b/notebooks/check_signal_from_dl2.ipynb
@@ -2,12 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "id": "445d62ac",
    "metadata": {},
    "outputs": [],
    "source": [
     "import glob\n",
     "import itertools\n",
+    "import yaml\n",
     "from pathlib import Path\n",
     "\n",
     "import numpy as np\n",
@@ -15,14 +17,15 @@
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.stats import WStatCountsStatistic\n",
-    "from magicctapipe.io import get_dl2_mean, get_stereo_events_old\n",
+    "from magicctapipe.io import get_dl2_mean, get_stereo_events, resource_file\n",
     "from magicctapipe.utils import calculate_off_coordinates\n",
     "from matplotlib import pyplot as plt"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
+   "id": "78aa4830",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,11 +38,14 @@
     ")\n",
     "\n",
     "# Get the pyplot default color cycle\n",
-    "colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]"
+    "colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]\n",
+    "with open(resource_file(\"test_config.yaml\"), \"rb\") as f:\n",
+    "    config = yaml.safe_load(f)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "948e4cad",
    "metadata": {},
    "source": [
     "# Load input DL2 data files"
@@ -48,6 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "d4e67d64",
    "metadata": {},
    "outputs": [
     {
@@ -623,7 +630,7 @@
     "\n",
     "# Apply the quality cuts\n",
     "print(f\"\\nQuality cuts: {quality_cuts}\")\n",
-    "event_data = get_stereo_events_old(event_data, quality_cuts)\n",
+    "event_data = get_stereo_events(event_data, config, quality_cuts)\n",
     "\n",
     "# Exclude the MAGIC-stereo combination events, since they are\n",
     "# poorly reconstructred with the current analysis scheme\n",
@@ -637,6 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "7a9b8a04",
    "metadata": {},
    "outputs": [
     {
@@ -829,6 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "027ee0d2",
    "metadata": {},
    "outputs": [
     {
@@ -849,6 +858,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c21ab64f",
    "metadata": {},
    "source": [
     "# Calculate the angular distances from ON and OFF regions"
@@ -857,6 +867,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "11ce9489",
    "metadata": {
     "scrolled": false
    },
@@ -1021,6 +1032,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73bfc60b",
    "metadata": {},
    "source": [
     "# Get an event list"
@@ -1029,6 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "1bc90db4",
    "metadata": {},
    "outputs": [
     {
@@ -1276,6 +1289,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1592b737",
    "metadata": {},
    "source": [
     "# Check the count map"
@@ -1284,6 +1298,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "5f7c6719",
    "metadata": {
     "scrolled": false
    },
@@ -1343,6 +1358,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "761fc696",
    "metadata": {},
    "source": [
     "# Check the theta2 distributions"
@@ -1351,6 +1367,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "6942bff5",
    "metadata": {
     "scrolled": false
    },
@@ -1496,6 +1513,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "089a9c51",
    "metadata": {
     "scrolled": false
    },
@@ -1585,6 +1603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8a2d5eee",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1592,6 +1611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d900ac02",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1599,9 +1619,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lstmagic",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "lstmagic"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1613,7 +1633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
in some places in the code the old function was still used (which was not not compatible with more LSTs).

some things to be fixed still
DL1 to DL2 step needs now a config file. In the basic script this is implemented, but needs to be included also in the autoMCP scripts

the naming of the telescopes is different LST-1 instead of LST1, MAGIC-I, MAGIC-II instead of M1 M2, and those names are used in the RF file names. In order to avoid rerunning/renaming the files we should look also for the files with the old names. 